### PR TITLE
fix(version): sync plugin manifests with package.json on version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     },
     "metadata": {
         "description": "Permanent coding companion for Claude Code (requires bun: https://bun.sh/install)",
-        "version": "0.3.0"
+        "version": "0.5.2"
     },
     "plugins": [
         {
             "name": "claude-buddy",
             "source": "./",
             "description": "Permanent coding companion for Claude Code \u2014 survives any update. MCP-based terminal pet with ASCII art, stats, reactions, and personality. Requires bun runtime (https://bun.sh/install).",
-            "version": "0.3.0",
+            "version": "0.5.2",
             "author": {
                 "name": "1270011"
             },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-buddy",
-    "version": "0.3.0",
+    "version": "0.5.2",
     "description": "Permanent coding companion for Claude Code \u2014 survives any update. MCP-based terminal pet with ASCII art, stats, reactions, and personality.",
     "author": {
         "name": "1270011"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "tui": "bun run cli/tui.tsx",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "gen:emoji-widths": "bun run scripts/gen-emoji-widths.ts"
+    "gen:emoji-widths": "bun run scripts/gen-emoji-widths.ts",
+    "sync-version": "bun run scripts/sync-version.ts",
+    "version": "bun run sync-version && git add .claude-plugin"
   },
   "files": [
     "server/",

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -1,0 +1,85 @@
+/**
+ * Sync version fields across the repo so package.json is the single source of truth.
+ *
+ * Run directly:
+ *   bun run sync-version
+ *
+ * Wired into npm lifecycle via `"version"` script in package.json so that
+ * `bun pm version <bump>` (or `npm version <bump>) updates all three files
+ * together and git-adds them for the auto-generated version commit.
+ *
+ * --check: exit non-zero without modifying files if anything is out of sync
+ *          (use this in CI).
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+
+const CHECK_ONLY = process.argv.includes("--check");
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+const { version } = pkg;
+if (typeof version !== "string" || !version) {
+  console.error("sync-version: package.json is missing a version field");
+  process.exit(2);
+}
+
+type Target = {
+  path: string;
+  read: () => unknown;
+  diffs: (doc: any) => { label: string; current: string }[];
+  apply: (doc: any) => void;
+};
+
+const targets: Target[] = [
+  {
+    path: ".claude-plugin/plugin.json",
+    read: () => JSON.parse(readFileSync(".claude-plugin/plugin.json", "utf8")),
+    diffs: (doc) => [{ label: "version", current: doc.version }],
+    apply: (doc) => {
+      doc.version = version;
+    },
+  },
+  {
+    path: ".claude-plugin/marketplace.json",
+    read: () =>
+      JSON.parse(readFileSync(".claude-plugin/marketplace.json", "utf8")),
+    diffs: (doc) => {
+      const out: { label: string; current: string }[] = [
+        { label: "metadata.version", current: doc.metadata?.version },
+      ];
+      for (let i = 0; i < (doc.plugins?.length ?? 0); i++) {
+        out.push({
+          label: `plugins[${i}].version`,
+          current: doc.plugins[i].version,
+        });
+      }
+      return out;
+    },
+    apply: (doc) => {
+      if (doc.metadata) doc.metadata.version = version;
+      for (const p of doc.plugins ?? []) p.version = version;
+    },
+  },
+];
+
+let drifted = false;
+for (const t of targets) {
+  const doc = t.read();
+  const diffs = t.diffs(doc).filter((d) => d.current !== version);
+  if (diffs.length === 0) continue;
+  drifted = true;
+  for (const d of diffs) {
+    const prefix = CHECK_ONLY ? "DRIFT" : "sync";
+    console.log(`${prefix}: ${t.path} :: ${d.label} ${d.current} -> ${version}`);
+  }
+  if (!CHECK_ONLY) {
+    t.apply(doc);
+    writeFileSync(t.path, JSON.stringify(doc, null, 4) + "\n");
+  }
+}
+
+if (CHECK_ONLY && drifted) {
+  console.error("sync-version: version fields are out of sync with package.json");
+  process.exit(1);
+}
+if (!drifted) console.log(`sync-version: all version fields already at ${version}`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { join, resolve, dirname } from "path";
+import pkg from "../package.json" with { type: "json" };
 
 import {
   generateBones,
@@ -122,7 +123,7 @@ function getInstructions(): string {
 const server = new McpServer(
   {
     name: "claude-buddy",
-    version: "0.3.0",
+    version: pkg.version,
   },
   {
     instructions: getInstructions(),


### PR DESCRIPTION
## Problem

The plugin manifests have been frozen at `0.3.0` across four releases:

| File | `main` HEAD |
|---|---|
| `package.json` | `0.5.2` |
| `.claude-plugin/plugin.json` | `0.3.0` |
| `.claude-plugin/marketplace.json` (metadata + plugins[0]) | `0.3.0` |
| `server/index.ts` MCP server `version` literal | `"0.3.0"` |

Each `chore: bump version to X` commit (#93, #97, #100, #102) only touched `package.json`. As a result:

- Marketplace clients reading `.claude-plugin/marketplace.json` see version `0.3.0`.
- The MCP server registers itself with the SDK (`new McpServer({ ..., version })`) as `0.3.0` regardless of installed version.
- Anyone debugging "what version of claude-buddy do I have?" gets a misleading answer.

## Fix

- New `scripts/sync-version.ts` makes `package.json` the single source of truth and writes the manifest files to match. Supports `--check` for CI drift detection (non-zero exit on mismatch).
- New `"version"` lifecycle script in `package.json` — `bun pm version <bump>` (or `npm version <bump>`) now runs the sync and `git add`s the manifest files into the auto-generated version commit. No follow-up commit needed.
- `server/index.ts` now imports `version` from `package.json` instead of a hardcoded literal, using the standard JSON import attribute syntax.
- Catches up the manifest files to the current `0.5.2`.

## Verification

- `bun run typecheck` passes (the `with { type: "json" }` import resolves cleanly).
- `bun test` passes — 246/246 tests, no failures.
- `bun run sync-version --check` exits 0 after this PR (drift resolved).
- Re-running `bun run sync-version` is idempotent — reports "all version fields already at 0.5.2" and does not modify any file.
- Smoke test: `bun -e 'import pkg from "./package.json" with { type: "json" }; console.log(pkg.version)'` prints `0.5.2`.

## Known minor side-effect

`scripts/sync-version.ts` uses `JSON.stringify` to write the manifest files. On the **first** future drift event (i.e. the next `bun pm version <bump>`), the existing `—` em-dash escapes in the description fields will be re-encoded as raw `—` characters. This is a one-time cosmetic round-trip; both forms are semantically identical JSON. Not addressed in this PR to keep the diff scoped to the version-sync fix, but happy to add normalization beforehand if you'd prefer the first sync commit to be purely version-only.

## Future-proofing

CI could add `bun run sync-version --check` as a guard so this regression cannot recur. Happy to add in a follow-up if desired.