### PR TITLE
fix(skill): split output rules + fix blank-reply bug for plain-text tools

### DIFF
--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -14,19 +14,25 @@ Handle the user's `/buddy` command using the claude-buddy MCP tools.
 **Before routing any command, check whether `mcp__claude_buddy__*` tools are registered in this session.** If they are NOT — Claude Code was unable to start the claude-buddy MCP server — do not attempt to call any buddy tool. The tool calls will fail with an unhelpful "tool not found" error. Instead, run this diagnostic and report the result to the user so they can fix the underlying cause:
 
 1. Check bun availability:
+
    ```bash
    command -v bun && bun --version
    ```
+
    The MCP launcher (`server/mcp-launcher.sh`) requires `bun` on PATH. If this command prints nothing, bun is missing — tell the user to install it (`curl -fsSL https://bun.sh/install | bash`), open a new terminal so PATH picks it up, and restart Claude Code. That is almost always the fix.
 
 2. If bun IS present, run the launcher directly to capture whatever error it emits. The launcher path depends on which marketplace installed the plugin; locate it first:
+
    ```bash
    find ~/.claude/plugins/cache -name mcp-launcher.sh -path '*claude-buddy*' 2>/dev/null
    ```
+
    Then execute the first result with stdin closed so it exits cleanly:
+
    ```bash
    <launcher-path> < /dev/null; echo "exit=$?"
    ```
+
    Report the stdout/stderr and exit code verbatim. Common causes: missing `bun`, corrupted plugin cache (suggest `claude plugin uninstall claude-buddy@claude-buddy && claude plugin install claude-buddy@claude-buddy`), or a `bun`-level error loading `server/index.ts`.
 
 3. If `$CLAUDE_CONFIG_DIR` is set in the environment, use that directory instead of `~/.claude` when searching for the launcher.
@@ -74,7 +80,11 @@ Based on `$ARGUMENTS`:
 
 ## CRITICAL OUTPUT RULES
 
-The MCP tools return pre-formatted ASCII art with ANSI colors, box-drawing characters, stat bars, and species art. This is the companion's visual identity.
+Different buddy tools return different shapes of output. The rules below ensure the companion's visual identity survives intact while plain-text replies stay visible to the user.
+
+### Visual-card outputs — strict verbatim
+
+These tools return pre-formatted ASCII art with ANSI colors, box-drawing characters, stat bars, and species art: `buddy_show`, `buddy_stats`, `buddy_pet`, `buddy_achievements`, `buddy_react`.
 
 **You MUST output the tool result text EXACTLY as returned — character for character, line for line.** Do NOT:
 
@@ -86,7 +96,17 @@ The MCP tools return pre-formatted ASCII art with ANSI colors, box-drawing chara
 
 **Just output the raw text content from the tool result. Nothing else.** The ASCII art IS the response.
 
-If the user mentions the buddy's name in normal conversation, call `buddy_react` with reason "turn" and display the result verbatim.
+### Plain-text outputs — verbatim + visible
+
+These tools return plain text, not ASCII art: `buddy_help`, `buddy_unmute`, `buddy_mute`, `buddy_frequency`, `buddy_style`, `buddy_statusline`, `buddy_list`, `buddy_rename`, `buddy_save`, `buddy_dismiss`, `buddy_set_personality`.
+
+Output the tool result verbatim inside your reply so the user can see it. You MAY add a one-sentence confirmation before or after if it clarifies what changed, but do NOT paraphrase the text itself.
+
+**Never emit a reply whose only visible content is the `<!-- buddy: ... -->` end-of-turn comment.** That comment is invisible in the rendered UI (markdown renderers hide HTML comments), so a plain-text tool result followed by only an HTML comment makes the reply look blank. Always echo the tool result in visible text.
+
+### Name reactions
+
+If the user mentions the buddy's name in normal conversation, call `buddy_react` with reason `"turn"` and display the result verbatim.
 
 ## Uninstall Orchestration
 

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -100,9 +100,13 @@ These tools return pre-formatted ASCII art with ANSI colors, box-drawing charact
 
 These tools return plain text, not ASCII art: `buddy_help`, `buddy_unmute`, `buddy_mute`, `buddy_frequency`, `buddy_style`, `buddy_statusline`, `buddy_list`, `buddy_rename`, `buddy_save`, `buddy_dismiss`, `buddy_set_personality`.
 
-Output the tool result verbatim inside your reply so the user can see it. You MAY add a one-sentence confirmation before or after if it clarifies what changed, but do NOT paraphrase the text itself.
+**The visible reply MUST include the tool result text verbatim — every time, on every call, even on repeated calls in the same session.** Treat each invocation as a fresh request from the user, not a "they've seen it before" signal. Tool result blocks live in your context, not in the user's rendered conversation; only what you put in your own reply reaches the screen.
 
-**Never emit a reply whose only visible content is the `<!-- buddy: ... -->` end-of-turn comment.** That comment is invisible in the rendered UI (markdown renderers hide HTML comments), so a plain-text tool result followed by only an HTML comment makes the reply look blank. Always echo the tool result in visible text.
+You MAY add a one-sentence confirmation before or after if it clarifies what changed, but do NOT paraphrase the text itself.
+
+**Hard floor — never break:** A reply whose only visible content is the `<!-- buddy: ... -->` end-of-turn comment is broken. HTML comments are hidden by the markdown renderer, so an HTML-comment-only reply renders blank. If you have nothing else to say, the tool result text alone is the correct reply.
+
+**Self-check before sending**: does your visible reply contain the tool's result text? If no, paste it in. The end-of-turn `<!-- buddy: ... -->` is _additional_, never _instead of_.
 
 ### Name reactions
 

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -74,7 +74,11 @@ Based on `$ARGUMENTS`:
 
 ## CRITICAL OUTPUT RULES
 
-The MCP tools return pre-formatted ASCII art with ANSI colors, box-drawing characters, stat bars, and species art. This is the companion's visual identity.
+Different buddy tools return different shapes of output. The rules below keep the companion's visual identity intact while making sure plain-text replies actually reach the user.
+
+### Visual-card outputs — strict verbatim
+
+These tools return pre-formatted ASCII art with ANSI colors, box-drawing characters, stat bars, and species art: `buddy_show`, `buddy_stats`, `buddy_pet`, `buddy_achievements`. This is the companion's visual identity.
 
 **You MUST output the tool result text EXACTLY as returned — character for character, line for line.** Do NOT:
 
@@ -85,6 +89,20 @@ The MCP tools return pre-formatted ASCII art with ANSI colors, box-drawing chara
 - Strip ANSI escape codes
 
 **Just output the raw text content from the tool result. Nothing else.** The ASCII art IS the response.
+
+### Plain-text outputs — verbatim and visible
+
+These tools return plain text, not ASCII art: `buddy_help`, `buddy_mute`, `buddy_unmute`, `buddy_frequency`, `buddy_style`, `buddy_statusline`, `buddy_list`, `buddy_rename`, `buddy_save`, `buddy_dismiss`, `buddy_set_personality`.
+
+**The visible reply MUST include the tool result text verbatim — every time, on every call, even on repeated calls in the same session.** Treat each invocation as a fresh request from the user, not a "they have seen it before" signal. Tool results are not rendered in the user's transcript; only what you write in your own reply reaches the screen.
+
+You MAY add a one-sentence confirmation before or after if it clarifies what changed, but do NOT paraphrase the text itself.
+
+**Hard floor — never break:** a reply that contains no visible text of its own is broken. A `buddy_react` call is not visible output — it reaches the user only through the statusline bubble — so a turn whose only content is a tool call renders blank. If you have nothing else to say, the tool result text alone is the correct reply.
+
+**Self-check before sending:** does your visible reply contain the tool's result text? If not, paste it in. The end-of-turn `buddy_react` call is _additional_, never _instead of_.
+
+### Reactions — statusline only
 
 If the user mentions the buddy's name in normal conversation, call `buddy_react` with reason "turn". Do NOT echo or quote the tool result — the reaction reaches the user only via the statusline speech bubble.
 

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -78,7 +78,7 @@ Different buddy tools return different shapes of output. The rules below keep th
 
 ### Visual-card outputs — strict verbatim
 
-These tools return pre-formatted ASCII art with ANSI colors, box-drawing characters, stat bars, and species art: `buddy_show`, `buddy_stats`, `buddy_pet`, `buddy_achievements`. This is the companion's visual identity.
+These tools return pre-formatted ASCII art with ANSI colors, box-drawing characters, stat bars, and species art: `buddy_show`, `buddy_stats`, `buddy_pet`, `buddy_achievements`, `buddy_summon`, `buddy_pick`. This is the companion's visual identity.
 
 **You MUST output the tool result text EXACTLY as returned — character for character, line for line.** Do NOT:
 


### PR DESCRIPTION
## Problem

The `CRITICAL OUTPUT RULES` section in `skills/buddy/SKILL.md` treats every buddy tool result as ASCII art that must be echoed verbatim with no commentary. That's correct for some tools, but several buddy tools return plain text:

`buddy_help`, `buddy_unmute`, `buddy_mute`, `buddy_frequency`, `buddy_style`, `buddy_statusline`, `buddy_list`, `buddy_rename`, `buddy_save`, `buddy_dismiss`, `buddy_set_personality`

Combined with the end-of-turn `<!-- buddy: ... -->` HTML comment pattern, the verbatim-no-commentary rule produced replies whose **only visible content was the HTML comment**. Markdown renderers hide HTML comments by default, so calling `/buddy help`, `/buddy mute`, `/buddy list`, etc. could result in a blank-looking reply to the user.

## Fix

Splits the rules into two buckets matching the actual tool response shapes:

- **Visual-card outputs (strict verbatim)** — `buddy_show`, `buddy_stats`, `buddy_pet`, `buddy_achievements`, `buddy_react`. Same rules as before: output exactly as returned, no commentary.
- **Plain-text outputs (verbatim + visible)** — the eleven plain-text tools listed above. Output the tool result verbatim inside the reply, with an optional one-sentence confirmation, so the user can actually see what happened. Explicitly warns against emitting a reply whose only visible content is the end-of-turn HTML comment.

The "name reactions" rule moves into its own subsection rather than being a trailing paragraph after the verbatim rules.

## Bonus markdown fix

Adds blank lines around the fenced code blocks in the MCP-failure diagnostic section so the bash blocks render correctly inside their numbered list items. CommonMark renderers vary on whether blank lines are required around fences inside list items; adding them is the safe form.

## Verification

- Pure docs change to a skill markdown file — no code, no tests, no runtime impact.
- The tool categorization was derived by reading `server/index.ts` and checking which `server.tool(...)` registrations return raw `card` markdown vs string templates.

## Out of scope

- Whether to add a similar plain-text bucket to other skills in this repo (none identified yet).
- Rewriting the visual-card rules themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized output guidance for visual-card tools with clearer verbatim-display requirements.
  * Added explicit rules for displaying plain-text tool results, including self-check and minimum-output requirements.
  * Clarified that reaction indicators appear only in the status line.
  * Identified the visual-card and plain-text tools covered by these rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->