### PR TITLE
fix(adapters): bound turn-comment LLM calls under the handler budget

### DIFF
--- a/adapters/omp/context.ts
+++ b/adapters/omp/context.ts
@@ -16,7 +16,7 @@ export interface OmpBuddyContext extends OmpBuddyUiContext {
   model: ExtensionContext["model"];
   modelRegistry: Pick<
     ExtensionContext["modelRegistry"],
-    "find" | "getApiKey" | "getProviderHeaders"
+    "find" | "getApiKeyForProvider" | "getProviderHeaders"
   >;
   sessionManager: Pick<ExtensionContext["sessionManager"], "getBranch">;
 }

--- a/adapters/omp/events.ts
+++ b/adapters/omp/events.ts
@@ -162,13 +162,17 @@ export function registerOmpBuddyEvents(pi: ExtensionAPI, deps: RegisterOmpBuddyE
       return;
     }
 
+    const config = deps.storage.loadOmpConfig();
     const generated = await generateTurnComment(
       ctx,
       progress.companion,
       event,
       deps.logger,
       deps.completeTurnComment ?? complete,
-      deps.storage.loadOmpConfig().turnCommentModel,
+      {
+        modelOverride: config.turnCommentModel,
+        timeoutMs: config.turnCommentTimeoutMs,
+      },
     );
     if (!generated.comment) {
       const assistantLength = isAssistantMessage(event.message) ? getAssistantText(event.message).length : 0;
@@ -294,14 +298,21 @@ function getAssistantText(message: AssistantMessage): string {
     .join("\n");
 }
 
+/** Well under OMP's 30s handler budget; cosmetic reactions must never stall a turn. */
+export const TURN_COMMENT_TIMEOUT_MS = 5_000;
+
 export async function generateTurnComment(
   ctx: OmpBuddyContext,
   companion: Companion,
   event: TurnEndEvent,
   logger: OmpBuddyLog,
   completeTurnComment: TurnCommentCompleter = complete,
-  modelOverride?: BuddyTurnCommentModelConfig,
+  options: {
+    modelOverride?: BuddyTurnCommentModelConfig;
+    timeoutMs?: number;
+  } = {},
 ): Promise<{ comment: string | null; source: "llm" | "fallback" | "none" }> {
+  const { modelOverride, timeoutMs = TURN_COMMENT_TIMEOUT_MS } = options;
   const assistantText = isAssistantMessage(event.message) ? getAssistantText(event.message) : "";
   if (!assistantText.trim()) {
     logger.warn("turn_comment_skipped", { reason: "empty_assistant_text" });
@@ -323,6 +334,7 @@ export async function generateTurnComment(
       promptLength: promptText.length,
       systemPromptLength: systemPrompt.length,
       toolResultCount: event.toolResults.length,
+      timeoutMs,
     });
     const promptDebugData: Record<string, unknown> = {
       assistantLength: assistantText.length,
@@ -357,7 +369,18 @@ export async function generateTurnComment(
         timestamp: Date.now(),
       };
 
-      try {
+      const controller = new AbortController();
+      let timedOut = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          controller.abort(new Error("Turn comment generation timed out"));
+          reject(new Error("Turn comment generation timed out"));
+        }, timeoutMs);
+      });
+
+      const workPromise = (async (): Promise<string | null> => {
         const response = await completeTurnComment(
           turnCommentModel,
           {
@@ -367,31 +390,55 @@ export async function generateTurnComment(
           {
             apiKey,
             headers,
+            signal: controller.signal,
           },
         );
 
-        if (response.stopReason !== "aborted") {
-          const text = response.content
-            .filter((block): block is TextContent => block.type === "text")
-            .map((block) => block.text)
-            .join("\n");
-          const normalized = normalizeBuddyComment(text);
-          logger.info("turn_comment_llm_result", {
-            stopReason: response.stopReason,
+        if (response.stopReason === "aborted") {
+          logger.warn("turn_comment_llm_aborted", {
             errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
-            contentTypes: response.content.map((block) => block.type),
-            contentCount: response.content.length,
-            rawLength: text.length,
-            normalizedLength: normalized.length,
           });
-          if (normalized) return { comment: normalized, source: "llm" };
-          logger.warn("turn_comment_llm_empty", { rawLength: text.length });
+          return null;
         }
-      } catch (error) {
-        logger.error("turn_comment_llm_error", {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
+
+        const text = response.content
+          .filter((block): block is TextContent => block.type === "text")
+          .map((block) => block.text)
+          .join("\n");
+        const normalized = normalizeBuddyComment(text);
+        logger.info("turn_comment_llm_result", {
+          stopReason: response.stopReason,
+          errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
+          contentTypes: response.content.map((block) => block.type),
+          contentCount: response.content.length,
+          rawLength: text.length,
+          normalizedLength: normalized.length,
         });
+        if (normalized) return normalized;
+        logger.warn("turn_comment_llm_empty", { rawLength: text.length });
+        return null;
+      })();
+
+      // Prevent unhandled rejection if timeout wins the race first.
+      workPromise.catch(() => {});
+
+      try {
+        const comment = await Promise.race([workPromise, timeoutPromise]);
+        clearTimeout(timeoutId);
+        if (comment) return { comment, source: "llm" };
+      } catch (error) {
+        clearTimeout(timeoutId);
+        if (timedOut) {
+          logger.warn("turn_comment_llm_timeout", {
+            timeoutMs,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        } else {
+          logger.error("turn_comment_llm_error", {
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+        }
       }
     } else {
       logger.warn("turn_comment_auth_unavailable", {

--- a/adapters/omp/events.ts
+++ b/adapters/omp/events.ts
@@ -301,6 +301,12 @@ function getAssistantText(message: AssistantMessage): string {
 /** Well under OMP's 30s handler budget; cosmetic reactions must never stall a turn. */
 export const TURN_COMMENT_TIMEOUT_MS = 5_000;
 
+export function resolveTurnCommentTimeoutMs(timeoutMs: number | undefined): number {
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : TURN_COMMENT_TIMEOUT_MS;
+}
+
 export async function generateTurnComment(
   ctx: OmpBuddyContext,
   companion: Companion,
@@ -312,7 +318,8 @@ export async function generateTurnComment(
     timeoutMs?: number;
   } = {},
 ): Promise<{ comment: string | null; source: "llm" | "fallback" | "none" }> {
-  const { modelOverride, timeoutMs = TURN_COMMENT_TIMEOUT_MS } = options;
+  const { modelOverride } = options;
+  const timeoutMs = resolveTurnCommentTimeoutMs(options.timeoutMs);
   const assistantText = isAssistantMessage(event.message) ? getAssistantText(event.message) : "";
   if (!assistantText.trim()) {
     logger.warn("turn_comment_skipped", { reason: "empty_assistant_text" });
@@ -320,133 +327,151 @@ export async function generateTurnComment(
   }
 
   const turnCommentModel = resolveTurnCommentModel(ctx, logger, modelOverride);
-  if (turnCommentModel) {
-    const toolResultsText = getToolResultsText(event);
-    const userText = getUserPromptText(ctx);
-    const systemPrompt = buildBuddyReactionSystemPrompt(companion);
-    const promptText = buildBuddyReactionPrompt(companion, assistantText, toolResultsText, userText);
-    logger.info("turn_comment_llm_attempt", {
-      modelProvider: turnCommentModel.provider,
-      modelId: turnCommentModel.id,
+  if (!turnCommentModel) {
+    logger.warn("turn_comment_llm_skipped", { reason: "no_model" });
+    const fallback = deriveTurnComment(companion, event.message);
+    logger.warn("turn_comment_fallback", {
+      fallbackLength: fallback?.length ?? 0,
       assistantLength: assistantText.length,
-      toolLength: toolResultsText.length,
-      userTextLength: userText.length,
-      promptLength: promptText.length,
-      systemPromptLength: systemPrompt.length,
-      toolResultCount: event.toolResults.length,
-      timeoutMs,
     });
-    const promptDebugData: Record<string, unknown> = {
-      assistantLength: assistantText.length,
-      toolLength: toolResultsText.length,
-      userTextLength: userText.length,
-    };
-    if (diagnosticPreviewsEnabled()) {
-      promptDebugData.systemPromptPreview = systemPrompt.slice(0, 800);
-      promptDebugData.promptPreview = promptText.slice(0, 1200);
-      promptDebugData.userTextPreview = userText.slice(0, 200);
-      promptDebugData.assistantPreview = assistantText.slice(0, 200);
-      promptDebugData.toolPreview = toolResultsText.slice(0, 200);
-    }
-    logger.debug("turn_comment_llm_prompt", promptDebugData);
+    return { comment: fallback, source: fallback ? "fallback" : "none" };
+  }
+
+  const toolResultsText = getToolResultsText(event);
+  const userText = getUserPromptText(ctx);
+  const systemPrompt = buildBuddyReactionSystemPrompt(companion);
+  const promptText = buildBuddyReactionPrompt(companion, assistantText, toolResultsText, userText);
+  logger.info("turn_comment_llm_attempt", {
+    modelProvider: turnCommentModel.provider,
+    modelId: turnCommentModel.id,
+    assistantLength: assistantText.length,
+    toolLength: toolResultsText.length,
+    userTextLength: userText.length,
+    promptLength: promptText.length,
+    systemPromptLength: systemPrompt.length,
+    toolResultCount: event.toolResults.length,
+    timeoutMs,
+  });
+  const promptDebugData: Record<string, unknown> = {
+    assistantLength: assistantText.length,
+    toolLength: toolResultsText.length,
+    userTextLength: userText.length,
+  };
+  if (diagnosticPreviewsEnabled()) {
+    promptDebugData.systemPromptPreview = systemPrompt.slice(0, 800);
+    promptDebugData.promptPreview = promptText.slice(0, 1200);
+    promptDebugData.userTextPreview = userText.slice(0, 200);
+    promptDebugData.assistantPreview = assistantText.slice(0, 200);
+    promptDebugData.toolPreview = toolResultsText.slice(0, 200);
+  }
+  logger.debug("turn_comment_llm_prompt", promptDebugData);
+
+  const userMessage: UserMessage = {
+    role: "user",
+    content: [{ type: "text", text: promptText }],
+    timestamp: Date.now(),
+  };
+
+  const controller = new AbortController();
+  let timedOut = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new Error("Turn comment generation timed out"));
+      reject(new Error("Turn comment generation timed out"));
+    }, timeoutMs);
+  });
+
+  const workPromise = (async (): Promise<string | null> => {
     let apiKey: string | undefined;
     try {
-      apiKey = await ctx.modelRegistry.getApiKey(turnCommentModel);
+      apiKey = await ctx.modelRegistry.getApiKeyForProvider(
+        turnCommentModel.provider,
+        undefined,
+        {
+          baseUrl: turnCommentModel.baseUrl,
+          modelId: turnCommentModel.id,
+          signal: controller.signal,
+        },
+      );
     } catch (error) {
       logger.warn("turn_comment_auth_unavailable", {
         message: error instanceof Error ? error.message : String(error),
       });
+      return null;
     }
+
     const headers = ctx.modelRegistry.getProviderHeaders(turnCommentModel.provider);
     logger.debug("turn_comment_auth", {
       hasApiKey: Boolean(apiKey),
       headerKeys: Object.keys(headers ?? {}),
     });
-    if (apiKey) {
-      const userMessage: UserMessage = {
-        role: "user",
-        content: [{ type: "text", text: promptText }],
-        timestamp: Date.now(),
-      };
-
-      const controller = new AbortController();
-      let timedOut = false;
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          timedOut = true;
-          controller.abort(new Error("Turn comment generation timed out"));
-          reject(new Error("Turn comment generation timed out"));
-        }, timeoutMs);
-      });
-
-      const workPromise = (async (): Promise<string | null> => {
-        const response = await completeTurnComment(
-          turnCommentModel,
-          {
-            systemPrompt: [systemPrompt],
-            messages: [userMessage],
-          },
-          {
-            apiKey,
-            headers,
-            signal: controller.signal,
-          },
-        );
-
-        if (response.stopReason === "aborted") {
-          logger.warn("turn_comment_llm_aborted", {
-            errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
-          });
-          return null;
-        }
-
-        const text = response.content
-          .filter((block): block is TextContent => block.type === "text")
-          .map((block) => block.text)
-          .join("\n");
-        const normalized = normalizeBuddyComment(text);
-        logger.info("turn_comment_llm_result", {
-          stopReason: response.stopReason,
-          errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
-          contentTypes: response.content.map((block) => block.type),
-          contentCount: response.content.length,
-          rawLength: text.length,
-          normalizedLength: normalized.length,
-        });
-        if (normalized) return normalized;
-        logger.warn("turn_comment_llm_empty", { rawLength: text.length });
-        return null;
-      })();
-
-      // Prevent unhandled rejection if timeout wins the race first.
-      workPromise.catch(() => {});
-
-      try {
-        const comment = await Promise.race([workPromise, timeoutPromise]);
-        clearTimeout(timeoutId);
-        if (comment) return { comment, source: "llm" };
-      } catch (error) {
-        clearTimeout(timeoutId);
-        if (timedOut) {
-          logger.warn("turn_comment_llm_timeout", {
-            timeoutMs,
-            message: error instanceof Error ? error.message : String(error),
-          });
-        } else {
-          logger.error("turn_comment_llm_error", {
-            message: error instanceof Error ? error.message : String(error),
-            stack: error instanceof Error ? error.stack : undefined,
-          });
-        }
-      }
-    } else {
+    if (!apiKey) {
       logger.warn("turn_comment_auth_unavailable", {
         message: "missing api key",
       });
+      return null;
     }
-  } else {
-    logger.warn("turn_comment_llm_skipped", { reason: "no_model" });
+
+    const response = await completeTurnComment(
+      turnCommentModel,
+      {
+        systemPrompt: [systemPrompt],
+        messages: [userMessage],
+      },
+      {
+        apiKey,
+        headers,
+        signal: controller.signal,
+      },
+    );
+
+    if (response.stopReason === "aborted") {
+      logger.warn("turn_comment_llm_aborted", {
+        errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
+      });
+      return null;
+    }
+
+    const text = response.content
+      .filter((block): block is TextContent => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    const normalized = normalizeBuddyComment(text);
+    logger.info("turn_comment_llm_result", {
+      stopReason: response.stopReason,
+      errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
+      contentTypes: response.content.map((block) => block.type),
+      contentCount: response.content.length,
+      rawLength: text.length,
+      normalizedLength: normalized.length,
+    });
+    if (normalized) return normalized;
+    logger.warn("turn_comment_llm_empty", { rawLength: text.length });
+    return null;
+  })();
+
+  // Prevent unhandled rejection if timeout wins the race first.
+  workPromise.catch(() => {});
+
+  try {
+    const comment = await Promise.race([workPromise, timeoutPromise]);
+    clearTimeout(timeoutId);
+    if (comment) return { comment, source: "llm" };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (timedOut) {
+      logger.warn("turn_comment_llm_timeout", {
+        timeoutMs,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } else {
+      logger.error("turn_comment_llm_error", {
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
   }
 
   const fallback = deriveTurnComment(companion, event.message);

--- a/adapters/omp/extension.test.ts
+++ b/adapters/omp/extension.test.ts
@@ -18,6 +18,7 @@ import {
   generateTurnComment,
   isOmpBashToolResult,
   looksLikeTestFailure,
+  TURN_COMMENT_TIMEOUT_MS,
   type OmpBuddyLog,
   type TurnCommentCompleter,
 } from "./events.ts";
@@ -415,10 +416,12 @@ describe("OMP turn-comment adaptation", () => {
     );
 
     expect(calls).toEqual([`key:${model.id}`, "headers:openai"]);
-    expect(completionOptions).toEqual({
+    expect(completionOptions).toMatchObject({
       apiKey: "secret-key",
       headers: { "x-provider-header": "present" },
     });
+    expect(completionOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(completionOptions?.signal?.aborted).toBe(false);
     expect(result).toEqual({
       comment: "*nods* the provider header made it through.",
       source: "llm",
@@ -592,6 +595,174 @@ describe("OMP turn-comment adaptation", () => {
     if (typeof prompt!.data.promptPreview === "string") {
       expect(prompt!.data.promptPreview.length).toBeLessThanOrEqual(1200);
     }
+  });
+
+  test("hanging completion aborts under budget and falls back", async () => {
+    const model = getBundledModels("openai")[0];
+    if (!model) throw new Error("Expected an OpenAI model fixture.");
+
+    let seenSignal: AbortSignal | undefined;
+    const hangingComplete: TurnCommentCompleter = async (_model, _request, options) => {
+      seenSignal = options?.signal;
+      await new Promise<never>(() => {});
+      throw new Error("unreachable");
+    };
+
+    const logs: Array<{ level: string; event: string; data: Record<string, unknown> }> = [];
+    const logger: OmpBuddyLog = {
+      info(event, data) { logs.push({ level: "info", event, data: data ?? {} }); },
+      warn(event, data) { logs.push({ level: "warn", event, data: data ?? {} }); },
+      error(event, data) { logs.push({ level: "error", event, data: data ?? {} }); },
+      debug(event, data) { logs.push({ level: "debug", event, data: data ?? {} }); },
+    };
+
+    const context = {
+      ui: { notify() {}, setStatus() {}, setWidget() {} },
+      model,
+      modelRegistry: {
+        find() {
+          return model;
+        },
+        async getApiKey() {
+          return "secret-key";
+        },
+        getProviderHeaders() {
+          return {};
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } satisfies OmpBuddyContext;
+
+    const event = {
+      type: "turn_end",
+      turnIndex: 3,
+      message: assistantMessage(
+        "The focused tests for `adapters/omp/events.ts` now pass.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const started = Date.now();
+    const result = await generateTurnComment(
+      context,
+      completionCompanion,
+      event,
+      logger,
+      hangingComplete,
+      { timeoutMs: 40 },
+    );
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(1_000);
+    expect(elapsed).toBeLessThan(TURN_COMMENT_TIMEOUT_MS);
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(seenSignal?.aborted).toBe(true);
+    expect(result.source).toBe("fallback");
+    expect(result.comment).toContain("adapters/omp/events.ts");
+    expect(logs.some((entry) => entry.event === "turn_comment_llm_timeout")).toBe(true);
+  });
+
+  test("hanging turn_end completion still renders fallback widget under handler budget", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "omp-buddy-hang-turn-"));
+    temporaryDirectories.push(stateDir);
+    const model = getBundledModels("openai")[0];
+    if (!model) throw new Error("Expected an OpenAI model fixture.");
+
+    const handlers = new Map<string, EventHandler>();
+    const commands = new Map<string, CommandHandler>();
+    const statuses: Array<{ key: string; text: string | undefined }> = [];
+    const widgets: Array<{ key: string; content: string[] | undefined }> = [];
+    const notifications: Array<{ message: string; type: string | undefined }> = [];
+
+    const extensionApi = {
+      on(event: string, handler: EventHandler) {
+        handlers.set(event, handler);
+      },
+      registerCommand(name: string, command: { handler: CommandHandler }) {
+        commands.set(name, command.handler);
+      },
+    } as ExtensionAPI;
+
+    const context = {
+      ui: {
+        setStatus(key: string, text: string | undefined) {
+          statuses.push({ key, text });
+        },
+        setWidget(key: string, content: string[] | undefined) {
+          widgets.push({ key, content });
+        },
+        notify(message: string, type?: "info" | "warning" | "error") {
+          notifications.push({ message, type });
+        },
+      },
+      model,
+      modelRegistry: {
+        find(provider: string, id: string) {
+          return provider === model.provider && id === model.id ? model : undefined;
+        },
+        async getApiKey() {
+          return "secret-key";
+        },
+        getProviderHeaders() {
+          return {};
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } satisfies OmpBuddyContext;
+
+    const hangingComplete: TurnCommentCompleter = async () => {
+      await new Promise<never>(() => {});
+      throw new Error("unreachable");
+    };
+
+    registerOmpBuddyExtension(extensionApi, {
+      stateDir,
+      completeTurnComment: hangingComplete,
+    });
+
+    const storage = new OmpBuddyStorage(stateDir);
+    storage.saveOmpConfig({
+      commentCooldown: 0,
+      turnCommentModel: { provider: model.provider, model: model.id },
+      turnCommentTimeoutMs: 40,
+    });
+
+    await emit(handlers, "session_start", { type: "session_start" }, context);
+    const companion = storage.loadActive();
+    expect(companion).not.toBeNull();
+
+    const turnEvent = {
+      type: "turn_end",
+      turnIndex: 1,
+      message: assistantMessage(
+        "The focused tests now pass for `adapters/omp/events.ts`.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const started = Date.now();
+    await emit(handlers, "turn_end", turnEvent, context);
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(1_000);
+    expect(elapsed).toBeLessThan(30_000);
+    const latest = storage.loadLatest();
+    expect(latest?.reason).toBe("turn");
+    expect(latest?.reaction).toContain("adapters/omp/events.ts");
+    const widget = widgets.at(-1)?.content?.join("\n") ?? "";
+    expect(widget).toContain(companion?.name ?? "");
+    expect(widget).toContain("adapters/omp/events.ts");
+    expect(commands.size).toBe(1);
+    expect(statuses.at(-1)?.key).toBe("buddy");
+    expect(notifications.length).toBeGreaterThan(0);
   });
 });
 describe("OMP looksLikeTestFailure", () => {

--- a/adapters/omp/extension.test.ts
+++ b/adapters/omp/extension.test.ts
@@ -18,6 +18,7 @@ import {
   generateTurnComment,
   isOmpBashToolResult,
   looksLikeTestFailure,
+  resolveTurnCommentTimeoutMs,
   TURN_COMMENT_TIMEOUT_MS,
   type OmpBuddyLog,
   type TurnCommentCompleter,
@@ -91,7 +92,7 @@ function createHarness(stateDir: string) {
       find() {
         return undefined;
       },
-      async getApiKey() {
+      async getApiKeyForProvider() {
         return undefined;
       },
       getProviderHeaders() {
@@ -340,9 +341,10 @@ const completionCompanion: Companion = {
 };
 
 describe("OMP turn-comment adaptation", () => {
-  test("uses OMP getApiKey and provider headers for contextual completion", async () => {
+  test("uses OMP getApiKeyForProvider and provider headers for contextual completion", async () => {
     const calls: string[] = [];
     let completionOptions: Parameters<TurnCommentCompleter>[2] | undefined;
+    let authOptions: { baseUrl?: string; modelId?: string; signal?: AbortSignal } | undefined;
     const model = getBundledModels("openai")[0];
     if (!model) throw new Error("Expected an OpenAI model fixture.");
     const context = {
@@ -356,8 +358,13 @@ describe("OMP turn-comment adaptation", () => {
         find() {
           return model;
         },
-        async getApiKey(selectedModel: Model) {
-          calls.push(`key:${selectedModel.id}`);
+        async getApiKeyForProvider(
+          provider: string,
+          _sessionId?: string,
+          options?: { baseUrl?: string; modelId?: string; signal?: AbortSignal },
+        ) {
+          calls.push(`key:${provider}:${options?.modelId ?? ""}`);
+          authOptions = options;
           return "secret-key";
         },
         getProviderHeaders(provider: string) {
@@ -415,7 +422,10 @@ describe("OMP turn-comment adaptation", () => {
       completeTurnComment,
     );
 
-    expect(calls).toEqual([`key:${model.id}`, "headers:openai"]);
+    expect(calls).toEqual([`key:${model.provider}:${model.id}`, "headers:openai"]);
+    expect(authOptions?.baseUrl).toBe(model.baseUrl);
+    expect(authOptions?.modelId).toBe(model.id);
+    expect(authOptions?.signal).toBeInstanceOf(AbortSignal);
     expect(completionOptions).toMatchObject({
       apiKey: "secret-key",
       headers: { "x-provider-header": "present" },
@@ -467,7 +477,7 @@ describe("OMP turn-comment adaptation", () => {
           find() {
             return model;
           },
-          async getApiKey() {
+          async getApiKeyForProvider() {
             return "secret-key";
           },
           getProviderHeaders() {
@@ -623,7 +633,7 @@ describe("OMP turn-comment adaptation", () => {
         find() {
           return model;
         },
-        async getApiKey() {
+        async getApiKeyForProvider() {
           return "secret-key";
         },
         getProviderHeaders() {
@@ -666,6 +676,167 @@ describe("OMP turn-comment adaptation", () => {
     expect(logs.some((entry) => entry.event === "turn_comment_llm_timeout")).toBe(true);
   });
 
+  test("hanging auth aborts under budget and falls back", async () => {
+    const model = getBundledModels("openai")[0];
+    if (!model) throw new Error("Expected an OpenAI model fixture.");
+
+    let seenSignal: AbortSignal | undefined;
+    let completionCalled = false;
+    const hangingAuthContext = {
+      ui: { notify() {}, setStatus() {}, setWidget() {} },
+      model,
+      modelRegistry: {
+        find() {
+          return model;
+        },
+        async getApiKeyForProvider(
+          _provider: string,
+          _sessionId?: string,
+          options?: { signal?: AbortSignal },
+        ) {
+          seenSignal = options?.signal;
+          await new Promise<never>(() => {});
+          return "secret-key";
+        },
+        getProviderHeaders() {
+          return {};
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } satisfies OmpBuddyContext;
+
+    const completeTurnComment: TurnCommentCompleter = async () => {
+      completionCalled = true;
+      throw new Error("completion should not run when auth hangs");
+    };
+
+    const logs: Array<{ level: string; event: string; data: Record<string, unknown> }> = [];
+    const logger: OmpBuddyLog = {
+      info(event, data) { logs.push({ level: "info", event, data: data ?? {} }); },
+      warn(event, data) { logs.push({ level: "warn", event, data: data ?? {} }); },
+      error(event, data) { logs.push({ level: "error", event, data: data ?? {} }); },
+      debug(event, data) { logs.push({ level: "debug", event, data: data ?? {} }); },
+    };
+
+    const event = {
+      type: "turn_end",
+      turnIndex: 5,
+      message: assistantMessage(
+        "The focused tests for `adapters/omp/events.ts` now pass.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const started = Date.now();
+    const result = await generateTurnComment(
+      hangingAuthContext,
+      completionCompanion,
+      event,
+      logger,
+      completeTurnComment,
+      { timeoutMs: 40 },
+    );
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(1_000);
+    expect(elapsed).toBeLessThan(TURN_COMMENT_TIMEOUT_MS);
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(seenSignal?.aborted).toBe(true);
+    expect(completionCalled).toBe(false);
+    expect(result.source).toBe("fallback");
+    expect(result.comment).toContain("adapters/omp/events.ts");
+    expect(logs.some((entry) => entry.event === "turn_comment_llm_timeout")).toBe(true);
+  });
+
+  test("invalid timeoutMs values fall back to the default positive bound", async () => {
+    expect(resolveTurnCommentTimeoutMs(undefined)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(0)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(-1)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(Number.NaN)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(Number.POSITIVE_INFINITY)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(null as unknown as number)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(250)).toBe(250);
+
+    const model = getBundledModels("openai")[0];
+    if (!model) throw new Error("Expected an OpenAI model fixture.");
+
+    const logs: Array<{ level: string; event: string; data: Record<string, unknown> }> = [];
+    const logger: OmpBuddyLog = {
+      info(event, data) { logs.push({ level: "info", event, data: data ?? {} }); },
+      warn(event, data) { logs.push({ level: "warn", event, data: data ?? {} }); },
+      error(event, data) { logs.push({ level: "error", event, data: data ?? {} }); },
+      debug(event, data) { logs.push({ level: "debug", event, data: data ?? {} }); },
+    };
+
+    const context = {
+      ui: { notify() {}, setStatus() {}, setWidget() {} },
+      model,
+      modelRegistry: {
+        find() {
+          return model;
+        },
+        async getApiKeyForProvider() {
+          return "secret-key";
+        },
+        getProviderHeaders() {
+          return {};
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } satisfies OmpBuddyContext;
+
+    const completeTurnComment: TurnCommentCompleter = async () => ({
+      role: "assistant",
+      content: [{ type: "text", text: "*nods* timeout sanitized." }],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 0,
+    });
+
+    const event = {
+      type: "turn_end",
+      turnIndex: 6,
+      message: assistantMessage(
+        "The focused tests for `adapters/omp/events.ts` now pass.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const result = await generateTurnComment(
+      context,
+      completionCompanion,
+      event,
+      logger,
+      completeTurnComment,
+      { timeoutMs: 0 },
+    );
+
+    expect(result).toEqual({
+      comment: "*nods* timeout sanitized.",
+      source: "llm",
+    });
+    const attempt = logs.find((entry) => entry.event === "turn_comment_llm_attempt");
+    expect(attempt?.data.timeoutMs).toBe(TURN_COMMENT_TIMEOUT_MS);
+  });
+
   test("hanging turn_end completion still renders fallback widget under handler budget", async () => {
     const stateDir = mkdtempSync(join(tmpdir(), "omp-buddy-hang-turn-"));
     temporaryDirectories.push(stateDir);
@@ -704,7 +875,7 @@ describe("OMP turn-comment adaptation", () => {
         find(provider: string, id: string) {
           return provider === model.provider && id === model.id ? model : undefined;
         },
-        async getApiKey() {
+        async getApiKeyForProvider() {
           return "secret-key";
         },
         getProviderHeaders() {

--- a/adapters/pi/events.test.ts
+++ b/adapters/pi/events.test.ts
@@ -8,6 +8,7 @@ import {
   looksLikeTestFailure,
   registerBuddyEvents,
   resolveTurnCommentModel,
+  resolveTurnCommentTimeoutMs,
   TURN_COMMENT_TIMEOUT_MS,
   type PiBuddyLog,
   type PiTurnCommentModelContext,
@@ -403,6 +404,204 @@ describe("generateTurnComment", () => {
     expect(result.source).toBe("fallback");
     expect(result.comment).toContain("adapters/pi/events.ts");
     expect(logs.some((entry) => entry.event === "turn_comment_llm_timeout")).toBe(true);
+  });
+
+  test("hanging auth aborts under budget and falls back", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "pi-buddy-hang-auth-"));
+    temporaryDirectories.push(stateDir);
+    const storage = new PiBuddyStorage(stateDir);
+    const model = getModels("openai")[0];
+    if (!model) throw new Error("Expected a Pi model fixture.");
+    storage.savePiConfig({ turnCommentModel: { provider: model.provider, model: model.id } });
+
+    let completionCalled = false;
+    const hangingAuthCtx = {
+      ui: { notify() {}, setStatus() {}, setWidget() {} },
+      model: undefined,
+      modelRegistry: {
+        find(provider: string, id: string) {
+          return provider === model.provider && id === model.id ? model : undefined;
+        },
+        async getApiKeyAndHeaders() {
+          await new Promise<never>(() => {});
+          return { ok: true, apiKey: "secret-key", headers: {} };
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } as unknown as ExtensionContext;
+
+    const logs: Array<{ level: string; event: string; data: Record<string, unknown> }> = [];
+    const logger: PiBuddyLog = {
+      info(event, data) { logs.push({ level: "info", event, data: data ?? {} }); },
+      warn(event, data) { logs.push({ level: "warn", event, data: data ?? {} }); },
+      error(event, data) { logs.push({ level: "error", event, data: data ?? {} }); },
+      debug(event, data) { logs.push({ level: "debug", event, data: data ?? {} }); },
+    };
+
+    const hangingComplete: TurnCommentCompleter = async () => {
+      completionCalled = true;
+      throw new Error("completion should not run when auth hangs");
+    };
+
+    const event = {
+      type: "turn_end",
+      turnIndex: 5,
+      message: assistantMessage(
+        "I updated adapters/pi/events.ts to stop random turn chatter.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const started = Date.now();
+    const result = await generateTurnComment(
+      hangingAuthCtx,
+      companion,
+      event,
+      logger,
+      hangingComplete,
+      {
+        modelOverride: storage.loadPiConfig().turnCommentModel,
+        timeoutMs: 40,
+      },
+    );
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(1_000);
+    expect(elapsed).toBeLessThan(TURN_COMMENT_TIMEOUT_MS);
+    expect(completionCalled).toBe(false);
+    expect(result.source).toBe("fallback");
+    expect(result.comment).toContain("adapters/pi/events.ts");
+    expect(logs.some((entry) => entry.event === "turn_comment_llm_timeout")).toBe(true);
+  });
+
+  test("auth throw falls back instead of rejecting the handler", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "pi-buddy-auth-throw-"));
+    temporaryDirectories.push(stateDir);
+    const storage = new PiBuddyStorage(stateDir);
+    const model = getModels("openai")[0];
+    if (!model) throw new Error("Expected a Pi model fixture.");
+    storage.savePiConfig({ turnCommentModel: { provider: model.provider, model: model.id } });
+
+    const ctx = {
+      ui: { notify() {}, setStatus() {}, setWidget() {} },
+      model: undefined,
+      modelRegistry: {
+        find(provider: string, id: string) {
+          return provider === model.provider && id === model.id ? model : undefined;
+        },
+        async getApiKeyAndHeaders() {
+          throw new Error("auth storage exploded");
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } as unknown as ExtensionContext;
+
+    const logs: Array<{ level: string; event: string; data: Record<string, unknown> }> = [];
+    const logger: PiBuddyLog = {
+      info(event, data) { logs.push({ level: "info", event, data: data ?? {} }); },
+      warn(event, data) { logs.push({ level: "warn", event, data: data ?? {} }); },
+      error(event, data) { logs.push({ level: "error", event, data: data ?? {} }); },
+      debug(event, data) { logs.push({ level: "debug", event, data: data ?? {} }); },
+    };
+
+    const event = {
+      type: "turn_end",
+      turnIndex: 6,
+      message: assistantMessage(
+        "I updated adapters/pi/events.ts to stop random turn chatter.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const result = await generateTurnComment(
+      ctx,
+      companion,
+      event,
+      logger,
+      async () => {
+        throw new Error("completion should not run when auth throws");
+      },
+      { modelOverride: storage.loadPiConfig().turnCommentModel },
+    );
+
+    expect(result.source).toBe("fallback");
+    expect(result.comment).toContain("adapters/pi/events.ts");
+    expect(logs.some((entry) => entry.event === "turn_comment_auth_unavailable")).toBe(true);
+  });
+
+  test("invalid timeoutMs values fall back to the default positive bound", async () => {
+    expect(resolveTurnCommentTimeoutMs(undefined)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(0)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(-1)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(Number.NaN)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(null as unknown as number)).toBe(TURN_COMMENT_TIMEOUT_MS);
+    expect(resolveTurnCommentTimeoutMs(250)).toBe(250);
+
+    const stateDir = mkdtempSync(join(tmpdir(), "pi-buddy-invalid-timeout-"));
+    temporaryDirectories.push(stateDir);
+    const storage = new PiBuddyStorage(stateDir);
+    const model = getModels("openai")[0];
+    if (!model) throw new Error("Expected a Pi model fixture.");
+    storage.savePiConfig({ turnCommentModel: { provider: model.provider, model: model.id } });
+
+    const logs: Array<{ level: string; event: string; data: Record<string, unknown> }> = [];
+    const logger: PiBuddyLog = {
+      info(event, data) { logs.push({ level: "info", event, data: data ?? {} }); },
+      warn(event, data) { logs.push({ level: "warn", event, data: data ?? {} }); },
+      error(event, data) { logs.push({ level: "error", event, data: data ?? {} }); },
+      debug(event, data) { logs.push({ level: "debug", event, data: data ?? {} }); },
+    };
+
+    const ctx = {
+      ui: { notify() {}, setStatus() {}, setWidget() {} },
+      model: undefined,
+      modelRegistry: {
+        find(provider: string, id: string) {
+          return provider === model.provider && id === model.id ? model : undefined;
+        },
+        async getApiKeyAndHeaders() {
+          return { ok: true, apiKey: "secret-key", headers: {} };
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } as unknown as ExtensionContext;
+
+    const event = {
+      type: "turn_end",
+      turnIndex: 7,
+      message: assistantMessage(
+        "I updated adapters/pi/events.ts to stop random turn chatter.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const result = await generateTurnComment(
+      ctx,
+      companion,
+      event,
+      logger,
+      async () => assistantMessage("*nods* timeout sanitized."),
+      {
+        modelOverride: storage.loadPiConfig().turnCommentModel,
+        timeoutMs: 0,
+      },
+    );
+
+    expect(result).toEqual({ comment: "*nods* timeout sanitized.", source: "llm" });
+    const attempt = logs.find((entry) => entry.event === "turn_comment_llm_attempt");
+    expect(attempt?.data.timeoutMs).toBe(TURN_COMMENT_TIMEOUT_MS);
   });
 });
 

--- a/adapters/pi/events.test.ts
+++ b/adapters/pi/events.test.ts
@@ -8,8 +8,10 @@ import {
   looksLikeTestFailure,
   registerBuddyEvents,
   resolveTurnCommentModel,
+  TURN_COMMENT_TIMEOUT_MS,
   type PiBuddyLog,
   type PiTurnCommentModelContext,
+  type TurnCommentCompleter,
 } from "./events.ts";
 import { registerBuddyCommands } from "./commands.ts";
 import { getNameReaction, getSuccessReaction } from "../../core/reactions.ts";
@@ -264,7 +266,7 @@ describe("generateTurnComment", () => {
         event,
         logger,
         fakeComplete,
-        storage.loadPiConfig().turnCommentModel,
+        { modelOverride: storage.loadPiConfig().turnCommentModel },
       );
 
       return { result, logs, longAssistant, longTool, longUser };
@@ -328,6 +330,79 @@ describe("generateTurnComment", () => {
     if (typeof prompt!.data.promptPreview === "string") {
       expect(prompt!.data.promptPreview.length).toBeLessThanOrEqual(1200);
     }
+  });
+
+  test("hanging completion aborts under budget and falls back", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "pi-buddy-hang-turn-comment-"));
+    temporaryDirectories.push(stateDir);
+    const storage = new PiBuddyStorage(stateDir);
+    const model = getModels("openai")[0];
+    if (!model) throw new Error("Expected a Pi model fixture.");
+    storage.savePiConfig({ turnCommentModel: { provider: model.provider, model: model.id } });
+
+    let seenSignal: AbortSignal | undefined;
+    const hangingComplete: TurnCommentCompleter = async (_model, _request, options) => {
+      seenSignal = options?.signal;
+      await new Promise<never>(() => {});
+      throw new Error("unreachable");
+    };
+
+    const logs: Array<{ level: string; event: string; data: Record<string, unknown> }> = [];
+    const logger: PiBuddyLog = {
+      info(event, data) { logs.push({ level: "info", event, data: data ?? {} }); },
+      warn(event, data) { logs.push({ level: "warn", event, data: data ?? {} }); },
+      error(event, data) { logs.push({ level: "error", event, data: data ?? {} }); },
+      debug(event, data) { logs.push({ level: "debug", event, data: data ?? {} }); },
+    };
+
+    const ctx = {
+      ui: { notify() {}, setStatus() {}, setWidget() {} },
+      model: undefined,
+      modelRegistry: {
+        find(provider: string, id: string) {
+          return provider === model.provider && id === model.id ? model : undefined;
+        },
+        async getApiKeyAndHeaders() {
+          return { ok: true, apiKey: "secret-key", headers: {} };
+        },
+      },
+      sessionManager: {
+        getBranch() {
+          return [];
+        },
+      },
+    } as unknown as ExtensionContext;
+
+    const event = {
+      type: "turn_end",
+      turnIndex: 4,
+      message: assistantMessage(
+        "I updated adapters/pi/events.ts to stop random turn chatter.",
+      ),
+      toolResults: [],
+    } satisfies TurnEndEvent;
+
+    const started = Date.now();
+    const result = await generateTurnComment(
+      ctx,
+      companion,
+      event,
+      logger,
+      hangingComplete,
+      {
+        modelOverride: storage.loadPiConfig().turnCommentModel,
+        timeoutMs: 40,
+      },
+    );
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(1_000);
+    expect(elapsed).toBeLessThan(TURN_COMMENT_TIMEOUT_MS);
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(seenSignal?.aborted).toBe(true);
+    expect(result.source).toBe("fallback");
+    expect(result.comment).toContain("adapters/pi/events.ts");
+    expect(logs.some((entry) => entry.event === "turn_comment_llm_timeout")).toBe(true);
   });
 });
 

--- a/adapters/pi/events.ts
+++ b/adapters/pi/events.ts
@@ -295,6 +295,13 @@ export type TurnCommentCompleter = (
 
 /** Well under typical harness handler budgets; cosmetic reactions must never stall a turn. */
 export const TURN_COMMENT_TIMEOUT_MS = 5_000;
+
+export function resolveTurnCommentTimeoutMs(timeoutMs: number | undefined): number {
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : TURN_COMMENT_TIMEOUT_MS;
+}
+
 export async function generateTurnComment(
   ctx: ExtensionContext,
   companion: Companion,
@@ -306,7 +313,8 @@ export async function generateTurnComment(
     timeoutMs?: number;
   } = {},
 ): Promise<{ comment: string | null; source: "llm" | "fallback" | "none" }> {
-  const { modelOverride, timeoutMs = TURN_COMMENT_TIMEOUT_MS } = options;
+  const { modelOverride } = options;
+  const timeoutMs = resolveTurnCommentTimeoutMs(options.timeoutMs);
   const assistantText = isAssistantMessage(event.message) ? getAssistantText(event.message) : "";
   if (!assistantText.trim()) {
     logger.warn("turn_comment_skipped", { reason: "empty_assistant_text" });
@@ -314,127 +322,144 @@ export async function generateTurnComment(
   }
 
   const turnCommentModel = resolveTurnCommentModel(ctx, logger, modelOverride);
-  if (turnCommentModel) {
-    const toolResultsText = getToolResultsText(event);
-    const userText = getUserPromptText(ctx);
-    const systemPrompt = buildBuddyReactionSystemPrompt(companion);
-    const promptText = buildBuddyReactionPrompt(companion, assistantText, toolResultsText, userText);
-    logger.info("turn_comment_llm_attempt", {
-      modelProvider: turnCommentModel.provider,
-      modelId: turnCommentModel.id,
+  if (!turnCommentModel) {
+    logger.warn("turn_comment_llm_skipped", { reason: "no_model" });
+    const fallback = deriveTurnComment(companion, event.message);
+    logger.warn("turn_comment_fallback", {
+      fallbackLength: fallback?.length ?? 0,
       assistantLength: assistantText.length,
-      toolLength: toolResultsText.length,
-      userTextLength: userText.length,
-      promptLength: promptText.length,
-      systemPromptLength: systemPrompt.length,
-      toolResultCount: event.toolResults.length,
-      timeoutMs,
     });
-    const promptDebugData: Record<string, unknown> = {
-      assistantLength: assistantText.length,
-      toolLength: toolResultsText.length,
-      userTextLength: userText.length,
-    };
-    if (diagnosticPreviewsEnabled()) {
-      promptDebugData.systemPromptPreview = systemPrompt.slice(0, 800);
-      promptDebugData.promptPreview = promptText.slice(0, 1200);
-      promptDebugData.userTextPreview = userText.slice(0, 200);
-      promptDebugData.assistantPreview = assistantText.slice(0, 200);
-      promptDebugData.toolPreview = toolResultsText.slice(0, 200);
+    return { comment: fallback, source: fallback ? "fallback" : "none" };
+  }
+
+  const toolResultsText = getToolResultsText(event);
+  const userText = getUserPromptText(ctx);
+  const systemPrompt = buildBuddyReactionSystemPrompt(companion);
+  const promptText = buildBuddyReactionPrompt(companion, assistantText, toolResultsText, userText);
+  logger.info("turn_comment_llm_attempt", {
+    modelProvider: turnCommentModel.provider,
+    modelId: turnCommentModel.id,
+    assistantLength: assistantText.length,
+    toolLength: toolResultsText.length,
+    userTextLength: userText.length,
+    promptLength: promptText.length,
+    systemPromptLength: systemPrompt.length,
+    toolResultCount: event.toolResults.length,
+    timeoutMs,
+  });
+  const promptDebugData: Record<string, unknown> = {
+    assistantLength: assistantText.length,
+    toolLength: toolResultsText.length,
+    userTextLength: userText.length,
+  };
+  if (diagnosticPreviewsEnabled()) {
+    promptDebugData.systemPromptPreview = systemPrompt.slice(0, 800);
+    promptDebugData.promptPreview = promptText.slice(0, 1200);
+    promptDebugData.userTextPreview = userText.slice(0, 200);
+    promptDebugData.assistantPreview = assistantText.slice(0, 200);
+    promptDebugData.toolPreview = toolResultsText.slice(0, 200);
+  }
+  logger.debug("turn_comment_llm_prompt", promptDebugData);
+
+  const userMessage: UserMessage = {
+    role: "user",
+    content: [{ type: "text", text: promptText }],
+    timestamp: Date.now(),
+  };
+
+  const controller = new AbortController();
+  let timedOut = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new Error("Turn comment generation timed out"));
+      reject(new Error("Turn comment generation timed out"));
+    }, timeoutMs);
+  });
+
+  const workPromise = (async (): Promise<string | null> => {
+    let auth: Awaited<ReturnType<ExtensionContext["modelRegistry"]["getApiKeyAndHeaders"]>>;
+    try {
+      auth = await ctx.modelRegistry.getApiKeyAndHeaders(turnCommentModel);
+    } catch (error) {
+      logger.warn("turn_comment_auth_unavailable", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return null;
     }
-    logger.debug("turn_comment_llm_prompt", promptDebugData);
-    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(turnCommentModel);
+
     logger.debug("turn_comment_auth", {
       ok: auth.ok,
       hasApiKey: auth.ok ? !!auth.apiKey : false,
       headerKeys: auth.ok ? Object.keys(auth.headers ?? {}) : [],
     });
-    if (auth.ok && auth.apiKey) {
-      const userMessage: UserMessage = {
-        role: "user",
-        content: [{ type: "text", text: promptText }],
-        timestamp: Date.now(),
-      };
-
-      const controller = new AbortController();
-      let timedOut = false;
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          timedOut = true;
-          controller.abort(new Error("Turn comment generation timed out"));
-          reject(new Error("Turn comment generation timed out"));
-        }, timeoutMs);
-      });
-
-      const workPromise = (async (): Promise<string | null> => {
-        const response = await completeTurnComment(
-          turnCommentModel,
-          {
-            systemPrompt,
-            messages: [userMessage],
-          },
-          {
-            apiKey: auth.apiKey,
-            headers: auth.headers,
-            signal: controller.signal,
-          },
-        );
-
-        if (response.stopReason === "aborted") {
-          logger.warn("turn_comment_llm_aborted", {
-            errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
-          });
-          return null;
-        }
-
-        const text = response.content
-          .filter((block): block is TextContent => block.type === "text")
-          .map((block) => block.text)
-          .join("\n");
-        const normalized = normalizeBuddyComment(text);
-        logger.info("turn_comment_llm_result", {
-          stopReason: response.stopReason,
-          errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
-          contentTypes: response.content.map((block) => block.type),
-          contentCount: response.content.length,
-          rawLength: text.length,
-          normalizedLength: normalized.length,
-        });
-        if (normalized) return normalized;
-        logger.warn("turn_comment_llm_empty", { rawLength: text.length });
-        return null;
-      })();
-
-      // Prevent unhandled rejection if timeout wins the race first.
-      workPromise.catch(() => {});
-
-      try {
-        const comment = await Promise.race([workPromise, timeoutPromise]);
-        clearTimeout(timeoutId);
-        if (comment) return { comment, source: "llm" };
-      } catch (error) {
-        clearTimeout(timeoutId);
-        if (timedOut) {
-          logger.warn("turn_comment_llm_timeout", {
-            timeoutMs,
-            message: error instanceof Error ? error.message : String(error),
-          });
-        } else {
-          logger.error("turn_comment_llm_error", {
-            message: error instanceof Error ? error.message : String(error),
-            stack: error instanceof Error ? error.stack : undefined,
-          });
-        }
-      }
-    } else {
+    if (!auth.ok || !auth.apiKey) {
       logger.warn("turn_comment_auth_unavailable", {
         ok: auth.ok,
         message: auth.ok ? "missing api key" : auth.error,
       });
+      return null;
     }
-  } else {
-    logger.warn("turn_comment_llm_skipped", { reason: "no_model" });
+
+    const response = await completeTurnComment(
+      turnCommentModel,
+      {
+        systemPrompt,
+        messages: [userMessage],
+      },
+      {
+        apiKey: auth.apiKey,
+        headers: auth.headers,
+        signal: controller.signal,
+      },
+    );
+
+    if (response.stopReason === "aborted") {
+      logger.warn("turn_comment_llm_aborted", {
+        errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
+      });
+      return null;
+    }
+
+    const text = response.content
+      .filter((block): block is TextContent => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    const normalized = normalizeBuddyComment(text);
+    logger.info("turn_comment_llm_result", {
+      stopReason: response.stopReason,
+      errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
+      contentTypes: response.content.map((block) => block.type),
+      contentCount: response.content.length,
+      rawLength: text.length,
+      normalizedLength: normalized.length,
+    });
+    if (normalized) return normalized;
+    logger.warn("turn_comment_llm_empty", { rawLength: text.length });
+    return null;
+  })();
+
+  // Prevent unhandled rejection if timeout wins the race first.
+  workPromise.catch(() => {});
+
+  try {
+    const comment = await Promise.race([workPromise, timeoutPromise]);
+    clearTimeout(timeoutId);
+    if (comment) return { comment, source: "llm" };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (timedOut) {
+      logger.warn("turn_comment_llm_timeout", {
+        timeoutMs,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } else {
+      logger.error("turn_comment_llm_error", {
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
   }
 
   const fallback = deriveTurnComment(companion, event.message);

--- a/adapters/pi/events.ts
+++ b/adapters/pi/events.ts
@@ -29,6 +29,7 @@ interface RegisterBuddyEventsDeps {
   storage: PiBuddyStorage;
   ui: PiBuddyUI;
   logger: PiBuddyLog;
+  completeTurnComment?: TurnCommentCompleter;
 }
 
 export function registerBuddyEvents(pi: ExtensionAPI, deps: RegisterBuddyEventsDeps): void {
@@ -152,14 +153,17 @@ export function registerBuddyEvents(pi: ExtensionAPI, deps: RegisterBuddyEventsD
       deps.ui.refresh(ctx, progress.companion, null, progress.achievements);
       return;
     }
-
+    const config = deps.storage.loadPiConfig();
     const generated = await generateTurnComment(
       ctx,
       progress.companion,
       event,
       deps.logger,
-      complete,
-      deps.storage.loadPiConfig().turnCommentModel,
+      deps.completeTurnComment ?? complete,
+      {
+        modelOverride: config.turnCommentModel,
+        timeoutMs: config.turnCommentTimeoutMs,
+      },
     );
     if (!generated.comment) {
       const assistantLength = isAssistantMessage(event.message) ? getAssistantText(event.message).length : 0;
@@ -283,19 +287,26 @@ function getAssistantText(message: AssistantMessage): string {
     .join("\n");
 }
 
-type TurnCommentCompleter = (
+export type TurnCommentCompleter = (
   model: Parameters<typeof complete>[0],
   context: Parameters<typeof complete>[1],
   options: Parameters<typeof complete>[2],
 ) => Promise<AssistantMessage>;
+
+/** Well under typical harness handler budgets; cosmetic reactions must never stall a turn. */
+export const TURN_COMMENT_TIMEOUT_MS = 5_000;
 export async function generateTurnComment(
   ctx: ExtensionContext,
   companion: Companion,
   event: TurnEndEvent,
   logger: PiBuddyLog,
   completeTurnComment: TurnCommentCompleter = complete,
-  modelOverride?: BuddyTurnCommentModelConfig,
+  options: {
+    modelOverride?: BuddyTurnCommentModelConfig;
+    timeoutMs?: number;
+  } = {},
 ): Promise<{ comment: string | null; source: "llm" | "fallback" | "none" }> {
+  const { modelOverride, timeoutMs = TURN_COMMENT_TIMEOUT_MS } = options;
   const assistantText = isAssistantMessage(event.message) ? getAssistantText(event.message) : "";
   if (!assistantText.trim()) {
     logger.warn("turn_comment_skipped", { reason: "empty_assistant_text" });
@@ -317,6 +328,7 @@ export async function generateTurnComment(
       promptLength: promptText.length,
       systemPromptLength: systemPrompt.length,
       toolResultCount: event.toolResults.length,
+      timeoutMs,
     });
     const promptDebugData: Record<string, unknown> = {
       assistantLength: assistantText.length,
@@ -344,7 +356,18 @@ export async function generateTurnComment(
         timestamp: Date.now(),
       };
 
-      try {
+      const controller = new AbortController();
+      let timedOut = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          controller.abort(new Error("Turn comment generation timed out"));
+          reject(new Error("Turn comment generation timed out"));
+        }, timeoutMs);
+      });
+
+      const workPromise = (async (): Promise<string | null> => {
         const response = await completeTurnComment(
           turnCommentModel,
           {
@@ -354,31 +377,55 @@ export async function generateTurnComment(
           {
             apiKey: auth.apiKey,
             headers: auth.headers,
+            signal: controller.signal,
           },
         );
 
-        if (response.stopReason !== "aborted") {
-          const text = response.content
-            .filter((block): block is TextContent => block.type === "text")
-            .map((block) => block.text)
-            .join("\n");
-          const normalized = normalizeBuddyComment(text);
-          logger.info("turn_comment_llm_result", {
-            stopReason: response.stopReason,
-            errorMessage: "errorMessage" in response ? (response as { errorMessage?: string }).errorMessage : undefined,
-            contentTypes: response.content.map((block) => block.type),
-            contentCount: response.content.length,
-            rawLength: text.length,
-            normalizedLength: normalized.length,
+        if (response.stopReason === "aborted") {
+          logger.warn("turn_comment_llm_aborted", {
+            errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
           });
-          if (normalized) return { comment: normalized, source: "llm" };
-          logger.warn("turn_comment_llm_empty", { rawLength: text.length });
+          return null;
         }
-      } catch (error) {
-        logger.error("turn_comment_llm_error", {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
+
+        const text = response.content
+          .filter((block): block is TextContent => block.type === "text")
+          .map((block) => block.text)
+          .join("\n");
+        const normalized = normalizeBuddyComment(text);
+        logger.info("turn_comment_llm_result", {
+          stopReason: response.stopReason,
+          errorMessage: "errorMessage" in response ? response.errorMessage : undefined,
+          contentTypes: response.content.map((block) => block.type),
+          contentCount: response.content.length,
+          rawLength: text.length,
+          normalizedLength: normalized.length,
         });
+        if (normalized) return normalized;
+        logger.warn("turn_comment_llm_empty", { rawLength: text.length });
+        return null;
+      })();
+
+      // Prevent unhandled rejection if timeout wins the race first.
+      workPromise.catch(() => {});
+
+      try {
+        const comment = await Promise.race([workPromise, timeoutPromise]);
+        clearTimeout(timeoutId);
+        if (comment) return { comment, source: "llm" };
+      } catch (error) {
+        clearTimeout(timeoutId);
+        if (timedOut) {
+          logger.warn("turn_comment_llm_timeout", {
+            timeoutMs,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        } else {
+          logger.error("turn_comment_llm_error", {
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+        }
       }
     } else {
       logger.warn("turn_comment_auth_unavailable", {

--- a/adapters/pi/index.ts
+++ b/adapters/pi/index.ts
@@ -3,12 +3,13 @@ import { BuddyCommandService } from "../../core/command-service.ts";
 import { PiIdentityProvider } from "./identity.ts";
 import { PiBuddyLogger } from "./logger.ts";
 import { registerBuddyCommands } from "./commands.ts";
-import { registerBuddyEvents } from "./events.ts";
+import { registerBuddyEvents, type TurnCommentCompleter } from "./events.ts";
 import { PiBuddyStorage } from "./storage.ts";
 import { PiBuddyUI } from "./ui.ts";
 
 export interface PiBuddyExtensionOptions {
   stateDir?: string;
+  completeTurnComment?: TurnCommentCompleter;
 }
 
 export default function registerPiBuddyExtension(
@@ -28,5 +29,11 @@ export default function registerPiBuddyExtension(
   const ui = new PiBuddyUI(storage);
 
   registerBuddyCommands(pi, { service, storage, ui });
-  registerBuddyEvents(pi, { service, storage, ui, logger });
+  registerBuddyEvents(pi, {
+    service,
+    storage,
+    ui,
+    logger,
+    completeTurnComment: options.completeTurnComment,
+  });
 }

--- a/adapters/shared/file-storage.ts
+++ b/adapters/shared/file-storage.ts
@@ -56,6 +56,7 @@ export const DEFAULT_FILE_BUDDY_CONFIG: FileBuddyConfig = {
   showRarity: true,
   statusLineEnabled: true,
   turnCommentModel: undefined,
+  turnCommentTimeoutMs: undefined,
   muted: false,
 };
 

--- a/core/model.ts
+++ b/core/model.ts
@@ -39,6 +39,8 @@ export interface BuddyConfig {
   showRarity: boolean;
   statusLineEnabled: boolean;
   turnCommentModel?: BuddyTurnCommentModelConfig;
+  /** Optional per-host bound for end-of-turn reaction LLM calls (ms). */
+  turnCommentTimeoutMs?: number;
 }
 
 export interface GlobalCounters {


### PR DESCRIPTION
Fixes #156.

## Problem

A live OMP session emits:

```
Extension ".../@ramarivera/coding-buddy/adapters/omp/index.ts" error: handler timed out after 30000ms
```

The per-turn reaction completion was awaited with **no timeout and no AbortSignal**, so it blocked the OMP extension handler until the model replied. OMP's handler budget is 30s, so a slow or hanging inference call took out the whole extension — leaving the widget half-rendered with nothing left running to repaint it. That is a likely contributor to reported "layout broken / no colour / resize never recovers" symptoms.

## Change

- `TURN_COMMENT_TIMEOUT_MS = 5000`, well under the 30s budget — reaction text is cosmetic and must never slow a turn
- `AbortController` + `signal` so the request is genuinely cancelled, not abandoned
- `Promise.race` + `clearTimeout`
- on timeout/abort → deterministic fallback tagged `source: "fallback"`
- configurable via `turnCommentTimeoutMs`
- same fix applied to the Pi adapter, which shared the defect

The correct pattern already existed in the same file (the personality generator); the per-turn path simply never got it.

## Verification

`bun test` 365 pass / 0 fail; `bun run typecheck` clean.

Regression tests drive a completer that genuinely never resolves (`await new Promise<never>(() => {})`) and assert: completion finishes far under the handler budget, the `AbortSignal` fires, the result is tagged `fallback`, and OMP's `turn_end` still paints the widget.

🤖 *This content was generated with AI assistance using Claude Opus 5.*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound turn-comment LLM calls with a configurable timeout and AbortSignal
> - Adds a 5,000 ms default timeout (`TURN_COMMENT_TIMEOUT_MS`) to `generateTurnComment` in both the OMP and Pi adapters, using `AbortController` and `Promise.race` to cancel and fall back on timeout.
> - Introduces `resolveTurnCommentTimeoutMs` to sanitize per-host timeout values from `BuddyConfig.turnCommentTimeoutMs`, falling back to the default for invalid inputs.
> - Auth in the OMP adapter now uses `modelRegistry.getApiKeyForProvider` (renamed from `getApiKey`) with provider/model context and an `AbortSignal`.
> - Both adapters accept an injected `completeTurnComment` dependency, allowing tests to simulate hangs and verify fallback behavior.
> - Behavioral Change: turn-comment generation that previously ran unbounded will now be aborted after 5 s (or the configured timeout), producing a fallback reaction instead of a comment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a40080d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->