### PR TITLE
fix(widget): recover OMP and Pi layout after terminal resize

### DIFF
--- a/adapters/omp/ui.ts
+++ b/adapters/omp/ui.ts
@@ -1,19 +1,13 @@
 import type { OmpBuddyUiContext } from "./context.ts";
 import type { Achievement } from "../../core/achievements.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
-import { renderAchievementsSummary, renderBuddyWidget } from "./renderers.ts";
+import { renderAchievementsSummary } from "./renderers.ts";
 import { OmpBuddyStorage } from "./storage.ts";
-import { getWidgetWidth, subscribeToWidgetResize } from "../shared/widget-layout.ts";
+import { BuddyWidget } from "../shared/widget-layout.ts";
 
 export class OmpBuddyUI {
   private readonly timers: Array<{ timer: Timer; clear: (timer: Timer) => void }> = [];
-  private resizeUnsubscribe: (() => void) | null = null;
-  private rendered: {
-    ctx: OmpBuddyUiContext;
-    companion: Companion;
-    reaction: ReactionState | null;
-    achievements: Achievement[];
-  } | null = null;
+  private readonly buddy = new BuddyWidget();
 
   constructor(private readonly storage: OmpBuddyStorage) {}
 
@@ -29,9 +23,7 @@ export class OmpBuddyUI {
 
   dispose(): void {
     this.cancelTimers();
-    this.resizeUnsubscribe?.();
-    this.resizeUnsubscribe = null;
-    this.rendered = null;
+    this.buddy.dispose();
   }
 
   refresh(
@@ -42,12 +34,15 @@ export class OmpBuddyUI {
   ): void {
     const currentReaction = reaction ?? null;
     const muted = this.storage.isMuted();
-    this.rendered = { ctx, companion, reaction: currentReaction, achievements: [...achievements] };
-    this.subscribeToResize();
+    const scheduler = getScheduler(ctx);
+
     ctx.ui.setStatus("buddy", undefined);
-    ctx.ui.setWidget(
-      "buddy",
-      renderBuddyWidget(companion, muted ? null : currentReaction, achievements, getWidgetWidth()),
+    this.buddy.refresh(
+      (lines) => ctx.ui.setWidget("buddy", lines),
+      companion,
+      muted ? null : currentReaction,
+      [...achievements],
+      scheduler ?? undefined,
     );
 
     this.cancelTimers();
@@ -55,8 +50,6 @@ export class OmpBuddyUI {
 
     const ttl = this.storage.loadConfig().reactionTTL;
     if (ttl <= 0) return;
-
-    const scheduler = getScheduler(ctx);
     if (!scheduler) return;
 
     const reactionTimestamp = currentReaction.timestamp;
@@ -83,20 +76,9 @@ export class OmpBuddyUI {
     unlocked: Array<{ achievement: Achievement; unlockedAt: number; slot?: string }>,
     remaining: Achievement[],
   ): void {
-    this.rendered = null;
+    this.buddy.clear();
     ctx.ui.setWidget("buddy", renderAchievementsSummary(unlocked, remaining));
     ctx.ui.notify(`Achievements: ${unlocked.length} unlocked`, "info");
-  }
-
-  private subscribeToResize(): void {
-    if (this.resizeUnsubscribe) return;
-    const resizeHandler = () => {
-      if (!this.rendered) return;
-      const { ctx, companion, reaction, achievements } = this.rendered;
-      const muted = this.storage.isMuted();
-      ctx.ui.setWidget("buddy", renderBuddyWidget(companion, muted ? null : reaction, achievements, getWidgetWidth()));
-    };
-    this.resizeUnsubscribe = subscribeToWidgetResize(resizeHandler);
   }
 }
 

--- a/adapters/pi/ui.ts
+++ b/adapters/pi/ui.ts
@@ -1,9 +1,9 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Achievement } from "../../core/achievements.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
-import { renderAchievementsSummary, renderBuddyWidget } from "./renderers.ts";
+import { renderAchievementsSummary } from "./renderers.ts";
 import { PiBuddyStorage } from "./storage.ts";
-import { getWidgetWidth, subscribeToWidgetResize } from "../shared/widget-layout.ts";
+import { BuddyWidget } from "../shared/widget-layout.ts";
 
 type PiBuddyUiContext = ExtensionContext & {
   setTimeout?: (callback: () => void, ms?: number) => Timer;
@@ -12,13 +12,7 @@ type PiBuddyUiContext = ExtensionContext & {
 
 export class PiBuddyUI {
   private readonly timers: Array<{ timer: Timer; clear: (timer: Timer) => void }> = [];
-  private resizeUnsubscribe: (() => void) | null = null;
-  private rendered: {
-    ctx: PiBuddyUiContext;
-    companion: Companion;
-    reaction: ReactionState | null;
-    achievements: Achievement[];
-  } | null = null;
+  private readonly buddy = new BuddyWidget();
 
   constructor(private readonly storage: PiBuddyStorage) {}
 
@@ -34,9 +28,7 @@ export class PiBuddyUI {
 
   dispose(): void {
     this.cancelTimers();
-    this.resizeUnsubscribe?.();
-    this.resizeUnsubscribe = null;
-    this.rendered = null;
+    this.buddy.dispose();
   }
 
   refresh(
@@ -47,12 +39,15 @@ export class PiBuddyUI {
   ): void {
     const currentReaction = reaction ?? null;
     const muted = this.storage.isMuted();
-    this.rendered = { ctx, companion, reaction: currentReaction, achievements: [...achievements] };
-    this.subscribeToResize();
+    const scheduler = getScheduler(ctx);
+
     ctx.ui.setStatus("buddy", undefined);
-    ctx.ui.setWidget(
-      "buddy",
-      renderBuddyWidget(companion, muted ? null : currentReaction, achievements, getWidgetWidth()),
+    this.buddy.refresh(
+      (lines) => ctx.ui.setWidget("buddy", lines),
+      companion,
+      muted ? null : currentReaction,
+      [...achievements],
+      scheduler ?? undefined,
     );
 
     this.cancelTimers();
@@ -60,8 +55,6 @@ export class PiBuddyUI {
 
     const ttl = this.storage.loadConfig().reactionTTL;
     if (ttl <= 0) return;
-
-    const scheduler = getScheduler(ctx);
     if (!scheduler) return;
 
     const reactionTimestamp = currentReaction.timestamp;
@@ -88,20 +81,9 @@ export class PiBuddyUI {
     unlocked: Array<{ achievement: Achievement; unlockedAt: number; slot?: string }>,
     remaining: Achievement[],
   ): void {
-    this.rendered = null;
+    this.buddy.clear();
     ctx.ui.setWidget("buddy", renderAchievementsSummary(unlocked, remaining));
     ctx.ui.notify(`Achievements: ${unlocked.length} unlocked`, "info");
-  }
-
-  private subscribeToResize(): void {
-    if (this.resizeUnsubscribe) return;
-    const resizeHandler = () => {
-      if (!this.rendered) return;
-      const { ctx, companion, reaction, achievements } = this.rendered;
-      const muted = this.storage.isMuted();
-      ctx.ui.setWidget("buddy", renderBuddyWidget(companion, muted ? null : reaction, achievements, getWidgetWidth()));
-    };
-    this.resizeUnsubscribe = subscribeToWidgetResize(resizeHandler);
   }
 }
 

--- a/adapters/shared/widget-layout.test.ts
+++ b/adapters/shared/widget-layout.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { Companion, ReactionState } from "../../core/model.ts";
+import type { Achievement } from "../../core/achievements.ts";
 import { BuddyWidget, displayWidth, renderCompanionWidget, stripAnsi, subscribeToWidgetResize } from "./widget-layout.ts";
 
 const companion: Companion = {
@@ -69,6 +70,58 @@ describe("shared buddy widget layout", () => {
     process.stdout.emit("resize");
     expect(calls).toBe(1);
   });
+  test("renders long reactions up to eight wrapped content lines", () => {
+    const longReaction: ReactionState = {
+      reaction: Array.from({ length: 32 }, (_, i) => `a${i.toString().padStart(2, "0")}`).join(" "),
+      reason: "test",
+      timestamp: 0,
+    };
+    const width = 32;
+    const lines = renderCompanionWidget(companion, longReaction, [], width, 0);
+    const plain = lines.map(stripAnsi).join("\n");
+
+    expect(lines.length).toBeLessThanOrEqual(10);
+    expect(lines.every((line) => displayWidth(line) <= width)).toBe(true);
+
+    const bubbleMatch = plain.match(/^ *\.-{12,}\.\s*$\n([\s\S]*?)\n^ *`-{12,}'\s*$/m);
+    expect(bubbleMatch).toBeDefined();
+    const contentLines = bubbleMatch![1]!.split("\n").filter((line) => line.trim().startsWith("|"));
+    expect(contentLines.length).toBe(8);
+    const joined = contentLines.join(" ");
+    expect(joined).toContain("a00");
+    expect(joined).toContain("a27");
+    expect(contentLines.at(-1)!).toContain("…");
+  });
+
+  test("renders multiple achievements in order within the line budget", () => {
+    const achievements: Achievement[] = [
+      { id: "a", name: "First Steps", description: "", icon: "🏆", check: () => true, secret: false },
+      { id: "b", name: "Good Buddy", description: "", icon: "🏆", check: () => true, secret: false },
+      { id: "c", name: "Long Haul", description: "", icon: "🏆", check: () => true, secret: false },
+    ];
+    const lines = renderCompanionWidget(companion, reaction, achievements, 80, 0);
+    const plain = lines.map(stripAnsi).join("\n");
+
+    expect(lines.every((line) => displayWidth(line) <= 80)).toBe(true);
+    expect(plain).toContain("🏆 First Steps");
+    expect(plain).toContain("🏆 Good Buddy");
+    expect(plain).toContain("🏆 Long Haul");
+    expect(plain.indexOf("🏆 First Steps")).toBeLessThan(plain.indexOf("🏆 Long Haul"));
+  });
+
+  test("shows achievements in the sprite output when the bubble cannot fit", () => {
+    const shortAchievements: Achievement[] = [
+      { id: "x", name: "Foo", description: "", icon: "🏆", check: () => true, secret: false },
+      { id: "y", name: "Bar", description: "", icon: "🏆", check: () => true, secret: false },
+    ];
+    const lines = renderCompanionWidget(companion, reaction, shortAchievements, 24, 0);
+    const plain = lines.map(stripAnsi).join("\n");
+
+    expect(lines.every((line) => displayWidth(line) <= 24)).toBe(true);
+    expect(plain).toContain("🏆 Foo");
+    expect(plain).toContain("🏆 Bar");
+  });
+
 });
 
 describe("east-asian width parity with the shell renderer", () => {
@@ -209,6 +262,7 @@ describe("BuddyWidget resize behavior", () => {
     process.stdout.emit("resize");
     widthRef.width = 24;
     scheduler.runAll();
+
     const last = captures.at(-1)!;
     expect(last.every((line) => displayWidth(line) <= 24)).toBe(true);
   });
@@ -261,4 +315,39 @@ describe("BuddyWidget resize behavior", () => {
 
     expect(scheduler.pendingCount()).toBe(0);
   });
+  test("swallows and logs render errors from the resize timer", () => {
+    const originalConsoleError = console.error;
+    const errors: unknown[][] = [];
+    console.error = ((...args: unknown[]) => {
+      errors.push(args);
+    }) as typeof console.error;
+    try {
+      const scheduler = createFakeScheduler();
+      let shouldThrow = false;
+      const widget = new BuddyWidget({
+        getWidth: () => {
+          if (shouldThrow) throw new Error("render boom");
+          return 80;
+        },
+        scheduler,
+        coalesceMs: 10,
+      });
+      activeWidgets.push(widget);
+      const captures: string[][] = [];
+      widget.refresh((lines) => captures.push(lines), companion, reaction, []);
+      expect(captures).toHaveLength(1);
+
+      shouldThrow = true;
+      process.stdout.emit("resize");
+      expect(scheduler.pendingCount()).toBe(1);
+      expect(() => scheduler.runAll()).not.toThrow();
+      expect(captures).toHaveLength(1);
+      expect(errors.length).toBe(1);
+      expect(String(errors[0]![0])).toContain("BuddyWidget render failed");
+      expect(errors[0]![1]).toBeInstanceOf(Error);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
 });

--- a/adapters/shared/widget-layout.test.ts
+++ b/adapters/shared/widget-layout.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import type { Companion, ReactionState } from "../../core/model.ts";
-import { displayWidth, renderCompanionWidget, stripAnsi, subscribeToWidgetResize } from "./widget-layout.ts";
+import { BuddyWidget, displayWidth, renderCompanionWidget, stripAnsi, subscribeToWidgetResize } from "./widget-layout.ts";
 
 const companion: Companion = {
   name: "Nimbus",
@@ -92,5 +92,173 @@ describe("east-asian width parity with the shell renderer", () => {
     for (const line of lines) {
       expect(displayWidth(line)).toBeLessThanOrEqual(width);
     }
+  });
+});
+
+function createFakeScheduler() {
+  let nextId = 1;
+  const timers: Array<{ id: number; fn: () => void; ms?: number }> = [];
+
+  class FakeTimer implements Timer {
+    constructor(private readonly id: number) {}
+    ref(): Timer {
+      return this;
+    }
+    unref(): Timer {
+      return this;
+    }
+    hasRef(): boolean {
+      return true;
+    }
+    refresh(): Timer {
+      return this;
+    }
+    [Symbol.toPrimitive](): number {
+      return this.id;
+    }
+  }
+
+
+  return {
+    setTimeout: (fn: () => void, ms?: number): Timer => {
+      const id = nextId++;
+      timers.push({ id, fn, ms });
+      return new FakeTimer(id);
+    },
+    clearTimer: (timer: Timer): void => {
+      const id = Number(timer);
+      const index = timers.findIndex((t) => t.id === id);
+      if (index >= 0) timers.splice(index, 1);
+    },
+    runAll: (): void => {
+      while (timers.length) {
+        const t = timers.shift()!;
+        t.fn();
+      }
+    },
+    pendingCount: (): number => timers.length,
+  };
+}
+
+function hasBubble(lines: string[]): boolean {
+  const plain = lines.map(stripAnsi).join("\n");
+  return /^ *\.[-]{12,}\.\s*$/m.test(plain) && /\|--\s+\S/.test(plain);
+}
+
+describe("BuddyWidget resize behavior", () => {
+  const activeWidgets: BuddyWidget[] = [];
+
+  afterEach(() => {
+    for (const widget of activeWidgets) widget.dispose();
+    activeWidgets.length = 0;
+  });
+
+  function makeWidget(widthRef: { width: number }) {
+    const scheduler = createFakeScheduler();
+    const captures: string[][] = [];
+    const widget = new BuddyWidget({
+      getWidth: () => widthRef.width,
+      scheduler,
+      coalesceMs: 10,
+    });
+    activeWidgets.push(widget);
+    return { widget, scheduler, captures, setWidget: (lines: string[]) => captures.push(lines) };
+  }
+
+  test("coalesces a burst of resize events into one re-render", () => {
+    const widthRef = { width: 80 };
+    const { widget, scheduler, captures, setWidget } = makeWidget(widthRef);
+
+    widget.refresh(setWidget, companion, reaction, []);
+    expect(captures).toHaveLength(1);
+
+    widthRef.width = 64;
+    process.stdout.emit("resize");
+    widthRef.width = 40;
+    process.stdout.emit("resize");
+    widthRef.width = 24;
+    process.stdout.emit("resize");
+    expect(scheduler.pendingCount()).toBe(1);
+
+    scheduler.runAll();
+    expect(captures).toHaveLength(2);
+    expect(captures[1]!.every((line) => displayWidth(line) <= 24)).toBe(true);
+  });
+
+  test("re-renders with the new width after a resize settles", () => {
+    const widthRef = { width: 80 };
+    const { widget, scheduler, captures, setWidget } = makeWidget(widthRef);
+
+    widget.refresh(setWidget, companion, reaction, []);
+    const first = captures[0]!;
+    expect(first.every((line) => displayWidth(line) <= 80)).toBe(true);
+
+    widthRef.width = 24;
+    process.stdout.emit("resize");
+    scheduler.runAll();
+    const last = captures.at(-1)!;
+    expect(last).not.toEqual(first);
+    expect(last.every((line) => displayWidth(line) <= 24)).toBe(true);
+  });
+
+  test("reads the width when the coalesced timer fires, not at the event time", () => {
+    const widthRef = { width: 80 };
+    const { widget, scheduler, captures, setWidget } = makeWidget(widthRef);
+
+    widget.refresh(setWidget, companion, reaction, []);
+    process.stdout.emit("resize");
+    widthRef.width = 24;
+    scheduler.runAll();
+    const last = captures.at(-1)!;
+    expect(last.every((line) => displayWidth(line) <= 24)).toBe(true);
+  });
+
+  test("drops the bubble at tiny widths and restores it when growing back", () => {
+    const widthRef = { width: 80 };
+    const { widget, scheduler, captures, setWidget } = makeWidget(widthRef);
+
+    widget.refresh(setWidget, companion, reaction, []);
+    expect(hasBubble(captures[0]!)).toBe(true);
+
+    widthRef.width = 24;
+    process.stdout.emit("resize");
+    scheduler.runAll();
+    expect(captures).toHaveLength(2);
+    expect(hasBubble(captures[1]!)).toBe(false);
+
+    widthRef.width = 80;
+    process.stdout.emit("resize");
+    scheduler.runAll();
+    expect(captures).toHaveLength(3);
+    expect(hasBubble(captures[2]!)).toBe(true);
+  });
+  test("cancels a pending resize before replacing its scheduler", () => {
+    const widthRef = { width: 80 };
+    const { widget, scheduler: firstScheduler, captures, setWidget } = makeWidget(widthRef);
+    const secondScheduler = createFakeScheduler();
+
+    widget.refresh(setWidget, companion, reaction, [], firstScheduler);
+    process.stdout.emit("resize");
+    expect(firstScheduler.pendingCount()).toBe(1);
+
+    widget.refresh(setWidget, { ...companion, name: "Current" }, reaction, [], secondScheduler);
+    expect(firstScheduler.pendingCount()).toBe(0);
+
+    widthRef.width = 24;
+    process.stdout.emit("resize");
+    expect(secondScheduler.pendingCount()).toBe(1);
+    secondScheduler.runAll();
+    expect(captures.at(-1)!.every((line) => displayWidth(line) <= 24)).toBe(true);
+  });
+
+  test("does not schedule work after the widget is cleared", () => {
+    const widthRef = { width: 80 };
+    const { widget, scheduler, setWidget } = makeWidget(widthRef);
+
+    widget.refresh(setWidget, companion, reaction, []);
+    widget.clear();
+    process.stdout.emit("resize");
+
+    expect(scheduler.pendingCount()).toBe(0);
   });
 });

--- a/adapters/shared/widget-layout.ts
+++ b/adapters/shared/widget-layout.ts
@@ -226,3 +226,105 @@ export function renderCompanionWidget(
     return `${" ".repeat(Math.max(0, safeWidth - cardWidth))}${body}`;
   });
 }
+
+export interface BuddyWidgetScheduler {
+  setTimeout(callback: () => void, ms?: number): Timer;
+  clearTimer(timer: Timer): void;
+}
+
+/**
+ * Width-aware buddy widget manager.
+ *
+ * Renders once when state arrives, then re-renders with the current terminal
+ * width after coalescing rapid process.stdout resize events. Callers supply
+ * only their harness `setWidget` and the current state; this class owns the
+ * resize subscription, debounce, and re-render logic.
+ */
+export class BuddyWidget {
+  private readonly getWidth: () => number;
+  private scheduler: BuddyWidgetScheduler;
+  private readonly coalesceMs: number;
+  private setWidget: ((lines: string[]) => void) | null = null;
+  private state: { companion: Companion; reaction: ReactionState | null; achievements: Achievement[] } | null = null;
+  private resizeUnsubscribe: (() => void) | null = null;
+  private timer: Timer | null = null;
+
+  constructor(options?: {
+    getWidth?: () => number;
+    scheduler?: BuddyWidgetScheduler;
+    coalesceMs?: number;
+  }) {
+    this.getWidth = options?.getWidth ?? getWidgetWidth;
+    this.scheduler = options?.scheduler ?? {
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimer: globalThis.clearTimeout.bind(globalThis),
+    };
+    this.coalesceMs = options?.coalesceMs ?? 50;
+  }
+
+  /**
+   * Render immediately with the current state and start (or renew) the shared
+   * resize subscription. The `setWidget` callback is the adapter's harness
+   * setter bound to the current UI context.
+   */
+  refresh(
+    setWidget: (lines: string[]) => void,
+    companion: Companion,
+    reaction: ReactionState | null,
+    achievements: Achievement[] = [],
+    scheduler?: BuddyWidgetScheduler,
+  ): void {
+    // Cancel any pending resize timer before swapping the scheduler or state
+    // so clearTimer is always paired with the scheduler that created the timer.
+    this.cancelTimer();
+    this.setWidget = setWidget;
+    if (scheduler) this.scheduler = scheduler;
+    this.state = { companion, reaction, achievements };
+    this.renderAndSet();
+    this.subscribe();
+  }
+
+  /** Stop reacting to resizes without unsubscribing from the shared listener. */
+  clear(): void {
+    this.cancelTimer();
+    this.state = null;
+  }
+
+  /** Tear down timers and the shared resize listener. */
+  dispose(): void {
+    this.cancelTimer();
+    this.resizeUnsubscribe?.();
+    this.resizeUnsubscribe = null;
+    this.state = null;
+    this.setWidget = null;
+  }
+
+  private subscribe(): void {
+    if (this.resizeUnsubscribe) return;
+    this.resizeUnsubscribe = subscribeToWidgetResize(() => this.onResize());
+  }
+
+  private onResize(): void {
+    // A cleared widget has no state/setter to render; don't schedule work.
+    if (!this.state || !this.setWidget) return;
+    this.cancelTimer();
+    this.timer = this.scheduler.setTimeout(() => {
+      this.timer = null;
+      this.renderAndSet();
+    }, this.coalesceMs);
+  }
+
+  private renderAndSet(): void {
+    if (!this.state || !this.setWidget) return;
+    const width = this.getWidth();
+    const lines = renderCompanionWidget(this.state.companion, this.state.reaction, this.state.achievements, width);
+    this.setWidget(lines);
+  }
+
+  private cancelTimer(): void {
+    if (this.timer !== null) {
+      this.scheduler.clearTimer(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/adapters/shared/widget-layout.ts
+++ b/adapters/shared/widget-layout.ts
@@ -164,16 +164,20 @@ function padLine(line: string, width: number): string {
 }
 
 function frameReaction(reaction: string, achievements: Achievement[], innerWidth: number): string[] {
-  const reactionLines = wrapReaction(reaction, innerWidth, 2);
-  const achievementLine = achievements[0] ? `🏆 ${achievements[0].name}` : "";
-  const content = [...reactionLines, ...(achievementLine ? [achievementLine] : [])]
-    .slice(0, 3)
-    .map((line) => `${DIM_ITALIC}${line}${RESET}`);
+  const maxContentLines = WIDGET_MAX_LINES - 2;
+  const trimmedReaction = reaction.trim();
+  const achievementLines = achievements.map((achievement) => `🏆 ${achievement.name}`);
+  const reactionMax = Math.max(0, maxContentLines - achievementLines.length);
+  const reactionLines = trimmedReaction ? wrapReaction(trimmedReaction, innerWidth, reactionMax) : [];
+  const content = reactionLines.concat(achievementLines).slice(0, maxContentLines);
+  const paddedContent = content.length === 1 ? ["", ...content] : content;
+
   const top = `.${"-".repeat(innerWidth + 2)}.`;
+  const bottom = `\`${"-".repeat(innerWidth + 2)}'`;
   return [
     top,
-    ...content.map((line) => `| ${padLine(line, innerWidth)} |`),
-    `\`${"-".repeat(innerWidth + 2)}'`,
+    ...paddedContent.map((line) => `| ${DIM_ITALIC}${padLine(line, innerWidth)}${RESET} |`),
+    bottom,
   ];
 }
 
@@ -205,16 +209,21 @@ export function renderCompanionWidget(
   const maxBubbleInner = safeWidth - spriteWidth - tailWidth - 4;
   const hasContent = Boolean(reaction?.reaction?.trim()) || achievements.length > 0;
   const canFrame = hasContent && maxBubbleInner >= minBubbleInner;
-  const bubbleInner = canFrame ? Math.min(44, maxBubbleInner) : 0;
+  const bubbleInner = canFrame ? maxBubbleInner : 0;
   const bubble = canFrame ? frameReaction(reaction?.reaction ?? "", achievements, bubbleInner) : [];
   const bubbleWidth = bubbleInner + 4;
   const cardWidth = canFrame ? bubbleWidth + tailWidth + spriteWidth : spriteWidth;
-  const height = Math.max(clippedArt.length + 1, bubble.length);
+
+  const achievementSprites = canFrame
+    ? []
+    : achievements.map((achievement) => `${DIM_ITALIC}${padLine(`🏆 ${achievement.name}`, spriteWidth)}${RESET}`);
+  const spriteBody = [...clippedArt, clippedLabel, ...achievementSprites];
+  const height = Math.max(spriteBody.length, bubble.length);
   const connectorRow = canFrame ? Math.min(bubble.length - 2, Math.max(1, Math.floor(bubble.length / 2))) : -1;
 
   return Array.from({ length: Math.min(WIDGET_MAX_LINES, height) }, (_, index) => {
-    const artLine = index < clippedArt.length ? clippedArt[index]! : index === clippedArt.length ? clippedLabel : "";
-    const sprite = padLine(artLine, spriteWidth);
+    const spriteLine = spriteBody[index] ?? "";
+    const sprite = padLine(spriteLine, spriteWidth);
     let body: string;
     if (canFrame) {
       const bubbleLine = bubble[index] ?? " ".repeat(bubbleWidth);
@@ -310,10 +319,13 @@ export class BuddyWidget {
     this.cancelTimer();
     this.timer = this.scheduler.setTimeout(() => {
       this.timer = null;
-      this.renderAndSet();
+      try {
+        this.renderAndSet();
+      } catch (error) {
+        console.error("BuddyWidget render failed:", error);
+      }
     }, this.coalesceMs);
   }
-
   private renderAndSet(): void {
     if (!this.state || !this.setWidget) return;
     const width = this.getWidth();

--- a/docs/statusline-performance-complaints.md
+++ b/docs/statusline-performance-complaints.md
@@ -13,3 +13,10 @@
 - Scope: floor usable width at `ART_W`; keep sprite and name intact through narrow-width degradation; preserve the statusline CI, TTY/non-TTY, runtime, and typecheck bars.
 - Acceptance: the golden check keeps the full pet name visible, no sprite or name row is sliced mid-character, and all requested verification commands pass.
 - Status: in progress.
+
+## 2026-07-26 — PR #158 resize review findings
+
+- Complaint: the resize timer could let a stale harness setter throw out of an uncaught callback, and the hero card silently clipped reactions, hid later achievements, and dropped achievements at narrow widths.
+- Scope: swallow/log timer-render errors; restore the prior reaction and achievement capability within the widget line budget, including a narrow-width non-bubble path.
+- Acceptance: timer exceptions don't escape; long reactions retain up to eight wrapped lines when space permits; all achievements render when budget permits; narrow cards still show achievement lines without exceeding width.
+- Status: in progress.


### PR DESCRIPTION
Part of #152.

## Problem

Claude Code's statusline re-lays-out and recovers within seconds of a terminal resize. **OMP does not** — on resize the widget breaks and stays broken for the rest of the session. Pi shares the defect.

## Change

Recovery lives in the shared layer (`adapters/shared/widget-layout.ts`, +102) rather than being implemented twice; both adapters get thinner as a result (`adapters/omp/ui.ts` and `adapters/pi/ui.ts`, −64 net between them). Adapters now only wire their harness's resize signal into the shared path.

Covers: re-layout on resize, no reuse of a stale cached width, shrinking below the width where the bubble is dropped and growing back restoring it, and coalescing rapid successive resizes so a drag-resize doesn't thrash.

## Note on CI

Any failures in the `buddy statusline colors` width tests are **not from this PR** — they are inherited and environment-dependent. `statusline/buddy-status.sh` resolves width by walking the process tree for a PTY and only falls back to `$COLUMNS` when that fails, so those tests pass where no tty is attached and fail where one is. A separate change makes width resolution deterministic; this branch should be rebased on it before merge.

🤖 *This content was generated with AI assistance using Claude Opus 5.*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OMP and Pi buddy widget layout recovery after terminal resize
> - Introduces `BuddyWidget` in [widget-layout.ts](https://github.com/ramarivera/coding-buddy/pull/158/files#diff-3b3b01820a908e7a6d03f263c95c369f326dc6bff0f7083007e26671c62df508), a width-aware manager that owns the resize subscription and coalesces rapid resize events via debounced scheduling, replacing manual `subscribeToWidgetResize` calls in both `OmpBuddyUI` and `PiBuddyUI`.
> - `BuddyWidget.clear()` stops resize-triggered re-renders while the achievements view is shown; `dispose()` cancels pending timers and unsubscribes cleanly.
> - Expands the reaction bubble to use the full available inner width (removes the 44-column cap) and raises the content line budget to 8 lines, supporting multiple achievements inside the bubble.
> - When the bubble cannot fit narrow terminals, achievement lines now render as italicized text beneath the sprite label instead of being dropped entirely.
> - Behavioral Change: resize re-renders are now debounced and coalesced; render errors during resize are swallowed and logged rather than propagated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe0ae16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->