### PR TITLE
feat(statusline): responsive density, and stop tests clobbering live companion state

### DIFF
--- a/adapters/shared/file-storage.ts
+++ b/adapters/shared/file-storage.ts
@@ -56,6 +56,7 @@ export const DEFAULT_FILE_BUDDY_CONFIG: FileBuddyConfig = {
   bubblePosition: "top",
   showRarity: true,
   statusLineEnabled: true,
+  statuslineDensity: "auto",
   turnCommentModel: undefined,
   turnCommentTimeoutMs: undefined,
   muted: false,

--- a/core/model.ts
+++ b/core/model.ts
@@ -38,6 +38,7 @@ export interface BuddyConfig {
   bubblePosition: "top" | "left";
   showRarity: boolean;
   statusLineEnabled: boolean;
+  statuslineDensity?: "auto" | "full" | "compact" | "minimal";
   turnCommentModel?: BuddyTurnCommentModelConfig;
   /** Optional per-host bound for end-of-turn reaction LLM calls (ms). */
   turnCommentTimeoutMs?: number;

--- a/scripts/ci/check-statusline.sh
+++ b/scripts/ci/check-statusline.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # CI golden check for the Claude Code statusline.
 #
-# Primary signal: loud text assertions over a width matrix + CJK / wide-emoji
-# fixtures. A broken render fails the build. VHS image goldens are a separate
-# step (scripts/ci/check-vhs-goldens.sh).
+# Primary signal: loud text assertions over a row/column density matrix +
+# CJK / wide-emoji / corrupt-eye fixtures. A broken render fails the build.
+# VHS image goldens are a separate step (scripts/ci/check-vhs-goldens.sh).
 #
 # Run from the repo root:
 #   bash scripts/ci/check-statusline.sh
@@ -16,11 +16,24 @@ fixture_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/statusline-fixture" && pwd)"
 pty_helper="$ROOT/scripts/ci/render-statusline-pty.py"
 payload='{"session_id":"ci","model":{"display_name":"CI"},"workspace":{"current_dir":"."}}'
 
-# Widths that have historically sheared the card / truncated the right edge.
-WIDTHS=(20 40 60 80 93 120 200)
+# Width/row budgets for each density tier. Full frames are 5 art rows + name;
+# compact is 3 art rows + name; minimal is a single sprite/face + name line.
+DENSITY_FULL_MIN=6
+DENSITY_FULL_MAX=8
+DENSITY_COMPACT_MIN=4
+DENSITY_COMPACT_MAX=4
+DENSITY_MINIMAL_MIN=1
+DENSITY_MINIMAL_MAX=1
 
 # Claude Code kills statusline scripts around 1s; stay under that budget.
-TIME_BUDGET_MS=1000
+TIME_BUDGET_MS=${BUDDY_STATUSLINE_TIME_BUDGET_MS:-1000}
+
+# Density matrix uses BUDDY_STATUSLINE_ROWS to make CI independent of the
+# ambient terminal size. Auto tier: full >=40 rows, compact 20-39, minimal <20.
+# Very narrow terminal widths force minimal regardless of rows.
+NARROW_COLS=40
+
+CLEANUP_DIRS=()
 
 fail() {
   echo "FAIL: $1" >&2
@@ -28,6 +41,17 @@ fail() {
     printf '%s\n' "$2" >&2
   fi
   exit 1
+}
+
+cleanup() {
+  for d in "${CLEANUP_DIRS[@]}"; do
+    rm -rf "$d" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+add_cleanup() {
+  CLEANUP_DIRS+=("$1")
 }
 
 # Strip SGR / CSI color sequences. Keep the rest of the glyphs intact so
@@ -89,34 +113,61 @@ now_ms() {
   fi
 }
 
-# Render statusline against a fixture dir at a fixed terminal width.
-# Uses a pseudo-TTY so buddy-status.sh's stty/PTY width probe sees the
-# requested cols (COLUMNS alone is ignored when the parent TTY is wide).
-# Sets globals: OUTPUT, PLAIN, ELAPSED_MS, EFFECTIVE_COLS
+# Augment a committed status.json with compactFrames/minimalFrames arrays.
+# Falls back to full frames when the current getStatusFrames() does not yet
+# emit the new arrays, so the CI harness is honest about missing density.
+write_density_status() {
+  local src_status="$1"
+  local dest_status="$2"
+  mkdir -p "$(dirname "$dest_status")"
+  bun "$ROOT/scripts/ci/write-density-status.ts" "$dest_status" < "$src_status"
+}
+
+# Build a temporary baseline fixture with density-aware status arrays.
+make_baseline_dir() {
+  local dest="$1"
+  rm -rf "$dest"
+  mkdir -p "$dest/buddy-state"
+  cp "$fixture_dir/buddy-state/config.json" "$dest/buddy-state/config.json"
+  write_density_status "$fixture_dir/buddy-state/status.json" "$dest/buddy-state/status.json"
+}
+
+# Render statusline against a fixture dir at a fixed terminal width/rows.
+# Sets globals: OUTPUT, PLAIN, ELAPSED_MS, EFFECTIVE_COLS, EFFECTIVE_ROWS.
 render_at() {
-  local config_dir="$1"
+  local source_dir="$1"
   local cols="$2"
-  local rendered errfile
+  local rows="${3:-50}"
+  local density="${4:-auto}"
+  local test_dir rendered errfile
+  test_dir=$(mktemp -d)
+  add_cleanup "$test_dir"
+  mkdir -p "$test_dir/buddy-state"
+  cp "$source_dir/buddy-state/status.json" "$test_dir/buddy-state/status.json"
+  cp "$source_dir/buddy-state/config.json" "$test_dir/buddy-state/config.json"
+  for _react in "$source_dir"/buddy-state/reaction.*.json; do
+    [ -f "$_react" ] && cp "$_react" "$test_dir/buddy-state/"
+  done
+
+  if [ "$density" != "auto" ]; then
+    jq --arg d "$density" '.statuslineDensity = $d' "$test_dir/buddy-state/config.json" \
+      > "$test_dir/buddy-state/config.json.tmp" \
+      && mv "$test_dir/buddy-state/config.json.tmp" "$test_dir/buddy-state/config.json"
+  fi
+
   errfile=$(mktemp)
-  # The fixtures write reaction.default.json, but paths.sh derives the
-  # per-session filename from CLAUDE_CODE_SESSION_ID / TMUX_PANE. Whichever of
-  # those happens to be set in the ambient environment decides which reaction
-  # file is read, so the check passed locally and failed on CI (no bubble
-  # rendered, because the reaction was looked up under a different session id).
-  # Pin them empty so the session id is always "default" and the result does
-  # not depend on where the check runs.
   rendered="$(
     CLAUDE_CODE_SESSION_ID="" \
     TMUX_PANE="" \
+    BUDDY_STATUSLINE_ROWS="$rows" \
     STATUSLINE_PAYLOAD="$payload" \
       python3 "$pty_helper" \
         "$cols" \
         "$ROOT" \
-        "$config_dir" \
+        "$test_dir" \
         "$ROOT/statusline/buddy-status.sh" \
         2>"$errfile"
   )"
-  # Prefer the child-only timer from the PTY helper (excludes harness import).
   ELAPSED_MS=$(sed -n 's/^STATUSLINE_ELAPSED_MS=//p' "$errfile" | tail -n1)
   rm -f "$errfile"
   case "$ELAPSED_MS" in
@@ -124,43 +175,67 @@ render_at() {
   esac
   OUTPUT="$(printf '%s' "$rendered" | tr -d '\r')"
   PLAIN="$(strip_ansi "$OUTPUT")"
-  # buddy-status.sh currently floors detected widths below 40 up to 125
-  # (owned by the resize worker). Assert against the budget the script
-  # actually honors so the matrix stays honest without forking that logic.
-  if [ "$cols" -lt 40 ]; then
-    EFFECTIVE_COLS=125
-  else
-    EFFECTIVE_COLS="$cols"
-  fi
+  # Assert the real terminal width budget; old <40 special-casing is gone.
+  EFFECTIVE_COLS="$cols"
+  EFFECTIVE_ROWS="$rows"
+}
+
+# Resolve the expected density tier for a (density, rows, cols) tuple.
+expected_tier() {
+  local density="${1:-auto}"
+  local rows="$2"
+  local cols="$3"
+  case "$density" in
+    full|compact|minimal)
+      printf '%s\n' "$density"
+      ;;
+    *)
+      if [ "$rows" -lt 20 ] || [ "$cols" -lt "$NARROW_COLS" ]; then
+        printf 'minimal\n'
+      elif [ "$rows" -lt 40 ]; then
+        printf 'compact\n'
+      else
+        printf 'full\n'
+      fi
+      ;;
+  esac
 }
 
 assert_render() {
   local label="$1"
   local cols="$2"
-  local expect_name="$3"
-  local expect_substr="${4:-}"
-  local budget="${EFFECTIVE_COLS:-$cols}"
+  local rows="$3"
+  local expect_name="$4"
+  local density="${5:-auto}"
+  local expect_substr="${6:-}"
 
-  local plain_lines line_count max_w w line
-  plain_lines=$(printf '%s\n' "$PLAIN")
-  line_count=$(printf '%s\n' "$plain_lines" | wc -l | tr -d ' ')
+  local tier min_lines max_lines line_count max_w w line
+  tier="$(expected_tier "$density" "$rows" "$cols")"
+  case "$tier" in
+    full)    min_lines=$DENSITY_FULL_MIN;    max_lines=$DENSITY_FULL_MAX    ;;
+    compact) min_lines=$DENSITY_COMPACT_MIN; max_lines=$DENSITY_COMPACT_MAX ;;
+    minimal) min_lines=$DENSITY_MINIMAL_MIN; max_lines=$DENSITY_MINIMAL_MAX ;;
+    *)       fail "[$label] unknown expected tier '$tier'" "$PLAIN"          ;;
+  esac
 
-  printf '%s\n' "$PLAIN" | grep -Fq "$expect_name" \
+  line_count=$(printf '%s' "$PLAIN" | awk 'END {print NR}')
+
+  printf '%s' "$PLAIN" | grep -Fq "$expect_name" \
     || fail "[$label] pet name '$expect_name' missing from output" "$PLAIN"
 
-  [ "$line_count" -ge 4 ] \
-    || fail "[$label] expected >=4 output lines, got $line_count" "$PLAIN"
+  [ "$line_count" -ge "$min_lines" ] && [ "$line_count" -le "$max_lines" ] \
+    || fail "[$label] expected $tier line count $min_lines-$max_lines, got $line_count" "$PLAIN"
 
   if [ -n "$expect_substr" ]; then
-    printf '%s\n' "$PLAIN" | grep -Fq "$expect_substr" \
+    printf '%s' "$PLAIN" | grep -Fq "$expect_substr" \
       || fail "[$label] expected substring missing: $expect_substr" "$PLAIN"
   fi
 
   # Sprite content must stay art, not descriptor words.
-  if printf '%s\n' "$PLAIN" | grep -Eq '<\([[:alpha:]]{2,}'; then
+  if printf '%s' "$PLAIN" | grep -Eq '<\([[:alpha:]]{2,}'; then
     fail "[$label] sprite looks corrupted (word leaked into eye slot)" "$PLAIN"
   fi
-  if printf '%s\n' "$PLAIN" | grep -Fq '{E}'; then
+  if printf '%s' "$PLAIN" | grep -Fq '{E}'; then
     fail "[$label] unresolved {E} eye placeholder in output" "$PLAIN"
   fi
 
@@ -171,16 +246,16 @@ assert_render() {
     if [ "$w" -gt "$max_w" ]; then
       max_w=$w
     fi
-    if [ "$w" -gt "$budget" ]; then
-      fail "[$label] row display width $w exceeds budget $budget (requested cols=$cols): $(printf '%q' "$line")" "$PLAIN"
+    if [ "$w" -gt "$cols" ]; then
+      fail "[$label] row display width $w exceeds requested cols=$cols: $(printf '%q' "$line")" "$PLAIN"
     fi
-  done <<< "$plain_lines"
+  done < <(printf '%s' "$PLAIN")
 
   # Bubble box: border rows and text rows must agree in outer width.
   # Bubble and art share a line ("| text |--   <(° ..."), so measure only the
-  # box segment. Ignore short art glyphs like the duck feet (`--') that also
+  # box segment. Ignore short art glyphs like the duck feet (\`--') that also
   # start with a backtick.
-  local box_w="" border_w text_w trimmed first bubble_only
+  local box_w="" trimmed first bubble_only seg_w
   while IFS= read -r line || [ -n "$line" ]; do
     [ -z "$line" ] && continue
     trimmed=$(printf '%s' "$line" | sed $'s/^[ \t\xE2\xA0\x80]*//')
@@ -188,15 +263,12 @@ assert_render() {
     bubble_only=""
     if [ "$first" = "." ]; then
       bubble_only=$(printf '%s' "$trimmed" | sed -n 's/^\(\.[-][-]*\.\).*/\1/p')
-    elif [ "$first" = '`' ]; then
-      bubble_only=$(printf '%s' "$trimmed" | sed -n "s/^\\(\`[-][-]*'\).*/\\1/p")
+    elif [ "$first" = '\`' ]; then
+      bubble_only=$(printf '%s' "$trimmed" | sed -n "s/^\\(\\\`[-][-]*'\\).*/\\1/p")
     elif [ "$first" = "|" ]; then
       bubble_only=$(printf '%s' "$trimmed" | sed -n 's/^\(|[^|]*|\).*/\1/p')
     fi
     [ -z "$bubble_only" ] && continue
-    # Real speech boxes are wide (INNER_W defaults to 44 → outer 48). Skip
-    # any short accidental match.
-    local seg_w
     seg_w=$(dwidth "$bubble_only")
     if [ "$seg_w" -lt 20 ]; then
       continue
@@ -212,15 +284,22 @@ assert_render() {
         fail "[$label] bubble border width $seg_w != $box_w" "$PLAIN"
       fi
     fi
-  done <<< "$plain_lines"
+  done < <(printf '%s' "$PLAIN")
 
-  # Name row must not outrun a reasonable panel width.
-  local name_line name_w
-  name_line=$(printf '%s\n' "$PLAIN" | grep -F "$expect_name" | head -n1 || true)
+  # Name row must stay within the panel budget. Minimal is a single line, so
+  # allow the full terminal width there; full/compact keep the existing panel
+  # sanity check.
+  local name_line name_w name_limit
+  name_line=$(printf '%s' "$PLAIN" | grep -F "$expect_name" | head -n1 || true)
   if [ -n "$name_line" ]; then
     name_w=$(dwidth "$(printf '%s' "$name_line" | sed $'s/^[ \t\xE2\xA0\x80]*//')")
-    if [ "$name_w" -gt 24 ]; then
-      fail "[$label] name row display width $name_w looks wider than the panel" "$PLAIN"
+    if [ "$tier" = "minimal" ]; then
+      name_limit=$cols
+    else
+      name_limit=24
+    fi
+    if [ "$name_w" -gt "$name_limit" ]; then
+      fail "[$label] name row display width $name_w exceeds limit $name_limit" "$PLAIN"
     fi
   fi
 
@@ -228,111 +307,145 @@ assert_render() {
     fail "[$label] statusline took ${ELAPSED_MS}ms (budget ${TIME_BUDGET_MS}ms)" "$PLAIN"
   fi
 
-  echo "OK: $label requested_cols=$cols budget=$budget lines=$line_count max_row_w=$max_w time=${ELAPSED_MS}ms name='$expect_name'"
+  echo "OK: $label density=$tier requested_cols=$cols rows=$rows lines=$line_count max_row_w=$max_w time=${ELAPSED_MS}ms name='$expect_name'"
 }
 
 # ─── Fixture 1: committed baseline (pikachu / Cobalt) ────────────────────────
-base_name="$(jq -r .name "$fixture_dir/buddy-state/status.json")"
-# Cold-start warmup (not timed). Claude Code also keeps the process hot after
-# the first tick; the budget is for steady-state, not first-ever spawn.
-render_at "$fixture_dir" 80 >/dev/null || true
-for cols in "${WIDTHS[@]}"; do
-  render_at "$fixture_dir" "$cols"
-  assert_render "baseline@${cols}" "$cols" "$base_name"
+baseline_dir=$(mktemp -d)
+add_cleanup "$baseline_dir"
+make_baseline_dir "$baseline_dir"
+base_name="$(jq -r .name "$baseline_dir/buddy-state/status.json")"
+
+# Warm-up (not timed). Claude Code keeps the process hot after the first tick.
+render_at "$baseline_dir" 80 50 auto >/dev/null || true
+
+# Row/column density matrix. BUDDY_STATUSLINE_ROWS is always explicit so the
+# results do not depend on the CI runner's terminal size.
+LABELS=(
+  "full@80x50"
+  "full@120x50"
+  "compact@60x30"
+  "compact@80x25"
+  "minimal@80x10"
+  "narrow-minimal@20x50"
+  "explicit-full@80x10"
+  "explicit-compact@80x50"
+  "explicit-minimal@80x50"
+  "invalid-normalizes@80x50"
+)
+ROWS=(50 50 30 25 10 50 10 50 50 50)
+COLS=(80 120 60 80 80 20 80 80 80 80)
+DENSITIES=(auto auto auto auto auto auto full compact minimal invalid)
+
+for i in "${!LABELS[@]}"; do
+  label="${LABELS[$i]}"
+  rows="${ROWS[$i]}"
+  cols="${COLS[$i]}"
+  density="${DENSITIES[$i]}"
+  render_at "$baseline_dir" "$cols" "$rows" "$density"
+  assert_render "$label" "$cols" "$rows" "$base_name" "$density"
 done
 
 # ─── Fixture 2: duck + CJK reaction (real prior breakage) ────────────────────
 cjk_dir=$(mktemp -d)
-cleanup() { rm -rf "$cjk_dir" "${emoji_dir:-}" "${corrupt_dir:-}"; }
-trap cleanup EXIT
+add_cleanup "$cjk_dir"
 mkdir -p "$cjk_dir/buddy-state"
 cp "$fixture_dir/buddy-state/config.json" "$cjk_dir/buddy-state/config.json"
 
-bun -e "
-import { writeFileSync } from 'fs';
-import { getStatusFrames } from './server/art.ts';
-const bones = {
-  rarity: 'common', species: 'duck', eye: '°', hat: 'none', shiny: false,
-  stats: { DEBUGGING: 50, PATIENCE: 50, CHAOS: 50, WISDOM: 50, SNARK: 50 },
-  peak: 'DEBUGGING', dump: 'PATIENCE',
-};
-const { frames, frameSequence } = getStatusFrames(bones);
-writeFileSync(process.argv[1], JSON.stringify({
-  name: 'Daffodil', species: 'duck', rarity: 'common', stars: '★',
-  face: '(°>', eye: '°', shiny: false, hat: 'none', reaction: '',
-  muted: false, achievement: '', frames, frameSequence,
-  level: 1, xp: 0, mood: 'focused',
-}));
-" "$cjk_dir/buddy-state/status.json"
+cat <<'JSON' | bun "$ROOT/scripts/ci/write-density-status.ts" "$cjk_dir/buddy-state/status.json"
+{"name":"Daffodil","species":"duck","rarity":"common","stars":"★","face":"(°>","eye":"°","shiny":false,"hat":"none","reaction":"","muted":false,"achievement":"","level":1,"xp":0,"mood":"focused"}
+JSON
 
 _ts=$(now_ms)
-printf '{"reaction":"编译通过了 你好世界","timestamp":%s,"reason":"turn"}\n' "$_ts" \
+printf '{\"reaction\":\"编译通过了 你好世界\",\"timestamp\":%s,\"reason\":\"turn\"}\n' "$_ts" \
   > "$cjk_dir/buddy-state/reaction.default.json"
 
-# Bubble rows use INNER_W=44 (box ~48 cols) today; the resize worker owns
-# shrinking/dropping bubbles under that floor. Exercise CJK width accounting
-# at budgets that can actually hold the current box.
+# Full width CJK/emoji bubble checks.
 for cols in 80 93 120 200; do
-  render_at "$cjk_dir" "$cols"
-  assert_render "cjk@${cols}" "$cols" "Daffodil" "你好"
-  printf '%s\n' "$PLAIN" | grep -Fq '<(°' \
+  render_at "$cjk_dir" "$cols" 50 auto
+  assert_render "cjk@${cols}" "$cols" 50 "Daffodil" auto "你好"
+  printf '%s' "$PLAIN" | grep -Fq '<(°' \
     || fail "[cjk@${cols}] duck eye row missing degree-sign glyph" "$PLAIN"
 done
 
+# Minimal sanity: name stays visible and nothing escapes the narrow budget.
+render_at "$cjk_dir" 20 10 auto
+assert_render "cjk-minimal@20x10" 20 10 "Daffodil" auto
+
 # ─── Fixture 3: wide-emoji reaction (VS16 / presentation) ────────────────────
 emoji_dir=$(mktemp -d)
+add_cleanup "$emoji_dir"
 mkdir -p "$emoji_dir/buddy-state"
 cp "$cjk_dir/buddy-state/status.json" "$emoji_dir/buddy-state/status.json"
 cp "$fixture_dir/buddy-state/config.json" "$emoji_dir/buddy-state/config.json"
 _ts=$(now_ms)
-printf '{"reaction":"ship it 🎉 ❤️ ✨","timestamp":%s,"reason":"success"}\n' "$_ts" \
+printf '{\"reaction\":\"ship it 🎉 ❤️ ✨\",\"timestamp\":%s,\"reason\":\"success\"}\n' "$_ts" \
   > "$emoji_dir/buddy-state/reaction.default.json"
 
 for cols in 80 93 120 200; do
-  render_at "$emoji_dir" "$cols"
-  assert_render "emoji@${cols}" "$cols" "Daffodil" "🎉"
+  render_at "$emoji_dir" "$cols" 50 auto
+  assert_render "emoji@${cols}" "$cols" 50 "Daffodil" auto "🎉"
 done
+
+render_at "$emoji_dir" 20 10 auto
+assert_render "emoji-minimal@20x10" 20 10 "Daffodil" auto
 
 # ─── Fixture 4: corrupt eye descriptor must not reach the sprite ─────────────
 # Regression for the live "<(normal ..." bug: even if bones.eye is the word
-# "normal", getStatusFrames must bake a real glyph.
+# "normal", getStatusFrames must bake a real glyph across every density array.
 corrupt_dir=$(mktemp -d)
+add_cleanup "$corrupt_dir"
 mkdir -p "$corrupt_dir/buddy-state"
 cp "$fixture_dir/buddy-state/config.json" "$corrupt_dir/buddy-state/config.json"
 
+cat <<'JSON' | bun "$ROOT/scripts/ci/write-density-status.ts" "$corrupt_dir/buddy-state/status.json"
+{"name":"Daffodil","species":"duck","rarity":"common","stars":"★","face":"(°>","eye":"normal","shiny":false,"hat":"none","reaction":"","muted":false,"achievement":"","level":1,"xp":0,"mood":"focused"}
+JSON
+
+# Ensure the corrupt eye descriptor was sanitized in every density array.
 bun -e "
-import { writeFileSync } from 'fs';
-import { getStatusFrames } from './server/art.ts';
-const bones = {
-  rarity: 'common', species: 'duck', eye: 'normal', hat: 'none', shiny: false,
-  stats: { DEBUGGING: 50, PATIENCE: 50, CHAOS: 50, WISDOM: 50, SNARK: 50 },
-  peak: 'DEBUGGING', dump: 'PATIENCE',
-};
-const { frames, frameSequence } = getStatusFrames(bones);
-for (const body of frames) {
-  if (body.includes('normal')) {
-    console.error('getStatusFrames leaked descriptor into frame:', body);
-    process.exit(2);
-  }
-  if (body.includes('{E}')) {
-    console.error('unresolved placeholder:', body);
-    process.exit(2);
+import { readFileSync } from 'fs';
+const status = JSON.parse(readFileSync(process.argv[1], 'utf8'));
+for (const key of ['frames', 'compactFrames', 'minimalFrames']) {
+  const arr = status[key];
+  if (!arr) continue;
+  for (const body of arr) {
+    if (body.includes('normal')) {
+      console.error('getStatusFrames leaked descriptor into', key, ':', body);
+      process.exit(2);
+    }
+    if (body.includes('{E}')) {
+      console.error('unresolved {E} placeholder in', key);
+      process.exit(2);
+    }
   }
 }
-writeFileSync(process.argv[1], JSON.stringify({
-  name: 'Daffodil', species: 'duck', rarity: 'common', stars: '★',
-  face: '(°>', eye: '°', shiny: false, hat: 'none', reaction: '',
-  muted: false, achievement: '', frames, frameSequence,
-  level: 1, xp: 0, mood: 'focused',
-}));
 " "$corrupt_dir/buddy-state/status.json"
 
-render_at "$corrupt_dir" 80
-assert_render "corrupt-eye@80" 80 "Daffodil"
-if printf '%s\n' "$PLAIN" | grep -Fq 'normal'; then
+render_at "$corrupt_dir" 80 50 auto
+assert_render "corrupt-eye@80" 80 50 "Daffodil" auto
+if printf '%s' "$PLAIN" | grep -Fq 'normal'; then
   fail "[corrupt-eye@80] literal normal appeared in render" "$PLAIN"
 fi
-printf '%s\n' "$PLAIN" | grep -Fq '<(°' \
+printf '%s' "$PLAIN" | grep -Fq '<(°' \
   || fail "[corrupt-eye@80] expected sanitized degree-sign eye" "$PLAIN"
+
+render_at "$corrupt_dir" 20 10 auto
+assert_render "corrupt-eye-minimal@20x10" 20 10 "Daffodil" auto
+
+# ─── Fixture 5: row override precedence smoke test ───────────────────────────
+# PTY rows are set to 50 by the helper, but BUDDY_STATUSLINE_ROWS=10 forces
+# minimal selection. This proves the env var wins over the PTY probe.
+render_at "$baseline_dir" 80 50 auto
+# Sanity: without the override the previous rows=50 call already exercised full.
+# Now pin minimal with the same terminal rows to assert override behavior.
+render_at "$baseline_dir" 80 10 auto
+assert_render "row-override@80x10" 80 10 "$base_name" auto
+
+# ─── Fixture 6: width invariants at the historic narrow width ──────────────────
+# COLUMNS=20 used to be special-cased; the new density path must keep the name
+# and sprite intact while honoring the actual 20-column budget.
+render_at "$baseline_dir" 20 50 auto
+assert_render "narrow-width@20x50" 20 50 "$base_name" auto
 
 echo "OK: all statusline golden assertions passed"

--- a/scripts/ci/check-statusline.sh
+++ b/scripts/ci/check-statusline.sh
@@ -357,7 +357,7 @@ cat <<'JSON' | bun "$ROOT/scripts/ci/write-density-status.ts" "$cjk_dir/buddy-st
 JSON
 
 _ts=$(now_ms)
-printf '{\"reaction\":\"编译通过了 你好世界\",\"timestamp\":%s,\"reason\":\"turn\"}\n' "$_ts" \
+printf '{"reaction":"编译通过了 你好世界","timestamp":%s,"reason":"turn"}\n' "$_ts" \
   > "$cjk_dir/buddy-state/reaction.default.json"
 
 # Full width CJK/emoji bubble checks.
@@ -379,7 +379,7 @@ mkdir -p "$emoji_dir/buddy-state"
 cp "$cjk_dir/buddy-state/status.json" "$emoji_dir/buddy-state/status.json"
 cp "$fixture_dir/buddy-state/config.json" "$emoji_dir/buddy-state/config.json"
 _ts=$(now_ms)
-printf '{\"reaction\":\"ship it 🎉 ❤️ ✨\",\"timestamp\":%s,\"reason\":\"success\"}\n' "$_ts" \
+printf '{"reaction":"ship it 🎉 ❤️ ✨","timestamp":%s,"reason":"success"}\n' "$_ts" \
   > "$emoji_dir/buddy-state/reaction.default.json"
 
 for cols in 80 93 120 200; do

--- a/scripts/ci/render-statusline-pty.py
+++ b/scripts/ci/render-statusline-pty.py
@@ -24,6 +24,14 @@ import termios
 import time
 
 
+def _positive_int(env_name: str, default: int) -> int:
+    value = os.environ.get(env_name, "")
+    if value and value.isdigit():
+        parsed = int(value)
+        if parsed > 0:
+            return parsed
+    return default
+
 def main() -> int:
     if len(sys.argv) != 5:
         print(
@@ -36,7 +44,7 @@ def main() -> int:
     root = sys.argv[2]
     config_dir = sys.argv[3]
     script = sys.argv[4]
-    rows = 30
+    rows = _positive_int("BUDDY_STATUSLINE_ROWS", 30)
     payload = os.environ.get(
         "STATUSLINE_PAYLOAD",
         '{"session_id":"ci","model":{"display_name":"CI"},"workspace":{"current_dir":"."}}',
@@ -47,7 +55,7 @@ def main() -> int:
         "printf %s "
         + repr(payload)
         + " | "
-        + f"COLUMNS={cols} BUDDY_FAKE_NOW=0 "
+        + f"COLUMNS={cols} BUDDY_FAKE_NOW=0 BUDDY_STATUSLINE_ROWS={rows} "
         + f"CLAUDE_CONFIG_DIR={config_dir!r} "
         + "CLAUDE_CODE_SESSION_ID= TMUX_PANE= BUDDY_SHELL= "
         + f"bash {script!r}"
@@ -57,11 +65,11 @@ def main() -> int:
     pid, fd = pty.fork()
     if pid == 0:
         os.chdir(root)
-        os.execvp("bash", ["bash", "-lc", cmd])
+        os.execvp("bash", ["bash", "-c", cmd])
 
     fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
     out = bytearray()
-    deadline = time.time() + 5.0
+    deadline = time.time() + 15.0
     while time.time() < deadline:
         readable, _, _ = select.select([fd], [], [], 0.1)
         if fd in readable:

--- a/scripts/ci/render-vhs-goldens.sh
+++ b/scripts/ci/render-vhs-goldens.sh
@@ -118,6 +118,9 @@ mkdir -p "$OUT_DIR"
 env_ci_was="${CI-}"
 unset CI || true
 export COLORTERM=truecolor
+# Pin rows so VHS golden renders stay at full density even when the terminal
+# emulator reports a smaller size. vhs-run-statusline.sh falls back to 50 too.
+export BUDDY_STATUSLINE_ROWS=50
 
 # Fixture generation uses only in-repo modules (server/art.ts). Never touch
 # the developer's live ~/.config/claude/buddy-state — CLAUDE_CONFIG_DIR is
@@ -127,32 +130,20 @@ mkdir -p "$gen_dir/cjk/buddy-state" "$gen_dir/emoji/buddy-state"
 cp scripts/ci/statusline-fixture/buddy-state/config.json "$gen_dir/cjk/buddy-state/config.json"
 cp scripts/ci/statusline-fixture/buddy-state/config.json "$gen_dir/emoji/buddy-state/config.json"
 
+bun "$ROOT/scripts/ci/write-density-status.ts" "$gen_dir/cjk/buddy-state/status.json" <<'JSON'
+{"name":"Daffodil","species":"duck","rarity":"common","stars":"★","face":"(°>","eye":"°","shiny":false,"hat":"none","reaction":"","muted":false,"achievement":"","level":1,"xp":0,"mood":"focused"}
+JSON
+cp "$gen_dir/cjk/buddy-state/status.json" "$gen_dir/emoji/buddy-state/status.json"
+
 bun -e "
 import { writeFileSync } from 'fs';
-import { getStatusFrames } from './server/art.ts';
-const bones = {
-  rarity: 'common', species: 'duck', eye: '°', hat: 'none', shiny: false,
-  stats: { DEBUGGING: 50, PATIENCE: 50, CHAOS: 50, WISDOM: 50, SNARK: 50 },
-  peak: 'DEBUGGING', dump: 'PATIENCE',
-};
-const { frames, frameSequence } = getStatusFrames(bones);
-const status = {
-  name: 'Daffodil', species: 'duck', rarity: 'common', stars: '★',
-  face: '(°>', eye: '°', shiny: false, hat: 'none', reaction: '',
-  muted: false, achievement: '', frames, frameSequence,
-  level: 1, xp: 0, mood: 'focused',
-};
-writeFileSync(process.argv[1], JSON.stringify(status));
-writeFileSync(process.argv[2], JSON.stringify(status));
-writeFileSync(process.argv[3], JSON.stringify({
+writeFileSync(process.argv[1], JSON.stringify({
   reaction: '编译通过了 你好世界', timestamp: Date.now(), reason: 'turn',
 }));
-writeFileSync(process.argv[4], JSON.stringify({
+writeFileSync(process.argv[2], JSON.stringify({
   reaction: 'ship it 🎉 ❤️ ✨', timestamp: Date.now(), reason: 'success',
 }));
 " \
-  "$gen_dir/cjk/buddy-state/status.json" \
-  "$gen_dir/emoji/buddy-state/status.json" \
   "$gen_dir/cjk/buddy-state/reaction.default.json" \
   "$gen_dir/emoji/buddy-state/reaction.default.json"
 

--- a/scripts/ci/statusline.tape
+++ b/scripts/ci/statusline.tape
@@ -3,7 +3,33 @@ Set Width 1400
 Set Height 500
 Set FontSize 14
 Set Shell "bash"
-Type "echo '{\"session_id\":\"ci\",\"model\":{\"display_name\":\"CI\"},\"workspace\":{\"current_dir\":\".\"}}' | CLAUDE_CONFIG_DIR=scripts/ci/statusline-fixture bash statusline/buddy-status.sh"
+
+# Generate temporary full/compact/minimal fixtures from the committed baseline
+# without touching production fixtures. The helper augments status.json with
+# compactFrames/minimalFrames when getStatusFrames() emits them.
+Hide
+Type "bash scripts/ci/vhs-density-fixtures.sh"
 Enter
-Sleep 12s
+Sleep 2s
+Show
+
+Type "clear"
+Enter
+Sleep 500ms
+
+# Full density: 50 rows gives the six-ish-line art + optional bubble.
+Type "COLUMNS=80 BUDDY_STATUSLINE_ROWS=50 bash scripts/ci/vhs-run-statusline.sh 80 scripts/ci/vhs-out/density-fixtures/full"
+Enter
+Sleep 2s
+
+# Compact density: three art rows + name, no bubble.
+Type "COLUMNS=80 BUDDY_STATUSLINE_ROWS=50 bash scripts/ci/vhs-run-statusline.sh 80 scripts/ci/vhs-out/density-fixtures/compact"
+Enter
+Sleep 2s
+
+# Minimal density: a single sprite/face + name line.
+Type "COLUMNS=80 BUDDY_STATUSLINE_ROWS=50 bash scripts/ci/vhs-run-statusline.sh 80 scripts/ci/vhs-out/density-fixtures/minimal"
+Enter
+Sleep 2s
+
 Screenshot scripts/ci/statusline.png

--- a/scripts/ci/vhs-density-fixtures.sh
+++ b/scripts/ci/vhs-density-fixtures.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Generate temporary full/compact/minimal statusline fixtures for the VHS tape.
+# Leaves the committed production fixture untouched and writes into the ignored
+# scripts/ci/vhs-out/ workspace.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+src_status="$ROOT/scripts/ci/statusline-fixture/buddy-state/status.json"
+out_dir="$ROOT/scripts/ci/vhs-out/density-fixtures"
+
+rm -rf "$out_dir"
+mkdir -p "$out_dir"/{full,compact,minimal}/buddy-state
+
+for d in full compact minimal; do
+  cp "$src_status" "$out_dir/$d/buddy-state/status.json"
+  printf '{"useCombinedStatus":false,"statuslineDensity":"%s"}\n' "$d" \
+    > "$out_dir/$d/buddy-state/config.json"
+done
+
+# Augment the committed fixture with full/compact/minimal frame arrays.
+cat "$src_status" | bun "$ROOT/scripts/ci/write-density-status.ts" "$out_dir/full/buddy-state/status.json"
+cp "$out_dir/full/buddy-state/status.json" "$out_dir/compact/buddy-state/status.json"
+cp "$out_dir/full/buddy-state/status.json" "$out_dir/minimal/buddy-state/status.json"
+
+echo "$out_dir"

--- a/scripts/ci/vhs-run-statusline.sh
+++ b/scripts/ci/vhs-run-statusline.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 # Invoked from VHS tapes. Args: <cols> <fixture-relpath-from-repo-root>
+# BUDDY_STATUSLINE_ROWS defaults to 50 (full density) so golden renders are not
+# sensitive to the VHS terminal's actual row count.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cols="${1:?cols}"
 fixture_rel="${2:?fixture}"
 payload='{"session_id":"ci","model":{"display_name":"CI"},"workspace":{"current_dir":"."}}'
+
+if [[ "$fixture_rel" = /* ]]; then
+  cfg_dir="$fixture_rel"
+else
+  cfg_dir="$ROOT/$fixture_rel"
+fi
+
+rows="${BUDDY_STATUSLINE_ROWS:-50}"
+
 cd "$ROOT"
 printf '%s' "$payload" \
   | COLUMNS="$cols" \
     BUDDY_FAKE_NOW=0 \
-    CLAUDE_CONFIG_DIR="$ROOT/$fixture_rel" \
+    BUDDY_STATUSLINE_ROWS="$rows" \
+    CLAUDE_CONFIG_DIR="$cfg_dir" \
     CLAUDE_CODE_SESSION_ID= \
     TMUX_PANE= \
     BUDDY_SHELL= \

--- a/scripts/ci/write-density-status.ts
+++ b/scripts/ci/write-density-status.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+/**
+ * Derives a status.json fixture with full/compact/minimal frame arrays.
+ *
+ * Reads a base status object from stdin, computes frames from species/eye/hat,
+ * and writes the augmented object to the file named by the first argument.
+ *
+ * Usage:
+ *   cat base-status.json | bun scripts/ci/write-density-status.ts dest.json
+ *   bun scripts/ci/write-density-status.ts dest.json < base-status.json
+ */
+import { writeFileSync } from "fs";
+import { getStatusFrames } from "../../server/art.ts";
+import { renderFace, resolveEyeGlyph, type Species } from "../../core/engine.ts";
+
+function deriveCompactFrames(fullFrames: string[]): string[] {
+  return fullFrames.map((body) => {
+    const lines = body.split("\n");
+    const selected: string[] = [];
+    for (const line of lines) {
+      if (selected.length >= 3) break;
+      if (line.trim() !== "") selected.push(line);
+    }
+    while (selected.length < 3) selected.push("");
+    return selected.join("\n");
+  });
+}
+
+function deriveMinimalFrames(species: Species, eye: string): string[] {
+  const face = renderFace(species, resolveEyeGlyph(eye));
+  return Array.from({ length: 4 }, () => face);
+}
+
+async function main() {
+  const dest = process.argv[2];
+  if (!dest) {
+    console.error("usage: write-density-status.ts <dest.json>");
+    process.exit(2);
+  }
+
+  let input = "";
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  const base = input ? JSON.parse(input) : {};
+
+  const bones = {
+    species: base.species ?? "pikachu",
+    rarity: base.rarity ?? "common",
+    eye: base.eye ?? "o",
+    hat: base.hat ?? "none",
+    shiny: base.shiny ?? false,
+    stats: base.stats ?? { DEBUGGING: 50, PATIENCE: 50, CHAOS: 50, WISDOM: 50, SNARK: 50 },
+    peak: base.peak ?? "DEBUGGING",
+    dump: base.dump ?? "PATIENCE",
+  };
+
+  const result = getStatusFrames(bones) as {
+    frames: string[];
+    frameSequence: number[];
+    compactFrames?: string[];
+    minimalFrames?: string[];
+  };
+
+  const compactFrames =
+    result.compactFrames && result.compactFrames.length > 0
+      ? result.compactFrames
+      : deriveCompactFrames(result.frames);
+
+  const minimalFrames =
+    result.minimalFrames && result.minimalFrames.length > 0
+      ? result.minimalFrames
+      : deriveMinimalFrames(bones.species as Species, bones.eye);
+
+  const out = {
+    ...base,
+    frames: result.frames,
+    compactFrames,
+    minimalFrames,
+    frameSequence: result.frameSequence,
+  };
+
+  writeFileSync(dest, JSON.stringify(out));
+}
+
+main();

--- a/server/art.ts
+++ b/server/art.ts
@@ -6,11 +6,12 @@
  * {E} is replaced with the eye character at render time.
  */
 
-import { resolveEyeGlyph, type Species, type Hat, type Rarity, type StatName, type BuddyBones } from "../core/engine.ts"
+import { renderFace, resolveEyeGlyph, type Species, type Hat, type Rarity, type StatName, type BuddyBones } from "../core/engine.ts"
 export { resolveEyeGlyph };
 import { HAT_ART } from "../core/art-data.ts";
-import { getRarityColor } from "./theme.ts";
+
 export { HAT_ART };
+import { getRarityColor } from "./theme.ts";
 
 // ─── Species art: 3 frames × 5 lines each ──────────────────────────────────
 
@@ -265,6 +266,8 @@ export const STATUS_FRAME_SEQUENCE: readonly number[] = [
 // \n-joined 5-line string (one jq call + mapfile in bash).
 export function getStatusFrames(bones: BuddyBones): {
   frames: string[];
+  compactFrames: string[];
+  minimalFrames: string[];
   frameSequence: number[];
 } {
   const resolveFrame = (frameIdx: number, eyeGlyph: string): string => {
@@ -277,16 +280,34 @@ export function getStatusFrames(bones: BuddyBones): {
     return art.join("\n");
   };
 
+  // Compact: keep the first three non-empty rows of each full frame. This
+  // preserves a hat if it occupies the top row, otherwise it drops the blank
+  // placeholder and shows the face/body.
+  const deriveCompactFrames = (fullFrames: string[]): string[] =>
+    fullFrames.map((body) => {
+      const lines = body.split("\n");
+      const selected: string[] = [];
+      for (const line of lines) {
+        if (selected.length >= 3) break;
+        if (line.trim() !== "") selected.push(line);
+      }
+      while (selected.length < 3) selected.push("");
+      return selected.join("\n");
+    });
+
   // Sanitize once at the boundary. Blink uses a literal "-" eye, which is
   // intentionally outside EYES and must not pass through resolveEyeGlyph.
   const eye = resolveEyeGlyph(bones.eye);
+  const frames = [
+    resolveFrame(0, eye),
+    resolveFrame(1, eye),
+    resolveFrame(2, eye),
+    resolveFrame(0, "-"),
+  ];
   return {
-    frames: [
-      resolveFrame(0, eye),
-      resolveFrame(1, eye),
-      resolveFrame(2, eye),
-      resolveFrame(0, "-"),
-    ],
+    frames,
+    compactFrames: deriveCompactFrames(frames),
+    minimalFrames: Array.from({ length: frames.length }, () => renderFace(bones.species, eye)),
     frameSequence: [...STATUS_FRAME_SEQUENCE],
   };
 }

--- a/server/state.test.ts
+++ b/server/state.test.ts
@@ -8,11 +8,19 @@ import { afterEach, describe, test, expect } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import {
-  normalizeConfig,
-  slugify,
-} from "./state.ts";
 import type { Companion } from "../core/engine.ts";
+
+// `state.ts` captures STATE_DIR at import time and ES modules are cached, so a
+// static import here pinned the module to the *real* buddy state dir before any
+// test could redirect it — and the later `await import("./state.ts")` handed
+// back that same cached instance. Not hypothetical: this silently overwrote the
+// user's live companion with this file's duck fixture on every `bun test` run.
+// Redirect CLAUDE_CONFIG_DIR BEFORE the first import, and never import the
+// module statically from this file.
+const GUARD_DIR = mkdtempSync(join(tmpdir(), "coding-buddy-state-guard-"));
+process.env.CLAUDE_CONFIG_DIR = GUARD_DIR;
+
+const { normalizeConfig, slugify } = await import("./state.ts");
 
 function makeTempStateDir(): string {
   return mkdtempSync(join(tmpdir(), "coding-buddy-state-"));
@@ -104,7 +112,18 @@ describe("normalizeConfig", () => {
     expect(normalizeConfig({ statuslineWidthAdjust: 6 }).statuslineWidthAdjust).toBe(6);
     expect(normalizeConfig({ statuslineWidthAdjust: "6" }).statuslineWidthAdjust).toBe(0);
   });
+
+  test("defaults and normalizes statuslineDensity", () => {
+    expect(normalizeConfig({}).statuslineDensity).toBe("auto");
+    expect(normalizeConfig({ statuslineDensity: "full" }).statuslineDensity).toBe("full");
+    expect(normalizeConfig({ statuslineDensity: "compact" }).statuslineDensity).toBe("compact");
+    expect(normalizeConfig({ statuslineDensity: "minimal" }).statuslineDensity).toBe("minimal");
+    expect(normalizeConfig({ statuslineDensity: "auto" }).statuslineDensity).toBe("auto");
+    expect(normalizeConfig({ statuslineDensity: "invalid" }).statuslineDensity).toBe("auto");
+    expect(normalizeConfig({ statuslineDensity: 123 }).statuslineDensity).toBe("auto");
+  });
 });
+
 
 describe("slugify", () => {
   test("lowercases input", () => {

--- a/server/state.test.ts
+++ b/server/state.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for state.ts — pure helpers (slugify, normalizeConfig) AND
  * the F3 reaction-provenance contract. The reaction-file I/O tests
- * below dynamically import `./state.ts` after setting `CLAUDE_CONFIG_DIR`,
- * because the module captures `STATE_DIR` at import time.
+ * below redirect `CLAUDE_CONFIG_DIR` before importing `./state.ts`, which now
+ * resolves its paths lazily (see the regression guard note below).
  */
 import { afterEach, describe, test, expect } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
@@ -10,10 +10,10 @@ import { tmpdir } from "os";
 import { join } from "path";
 import type { Companion } from "../core/engine.ts";
 
-// `state.ts` captures STATE_DIR at import time and ES modules are cached, so a
-// static import here pinned the module to the *real* buddy state dir before any
-// test could redirect it — and the later `await import("./state.ts")` handed
-// back that same cached instance. Not hypothetical: this silently overwrote the
+// REGRESSION GUARD. `state.ts` now resolves its paths lazily, but this file must
+// still redirect before importing it: a static import here previously pinned the
+// module to the *real* buddy state dir, and the later `await import(...)` handed
+// back that same cached instance. Not hypothetical: it silently overwrote the
 // user's live companion with this file's duck fixture on every `bun test` run.
 // Redirect CLAUDE_CONFIG_DIR BEFORE the first import, and never import the
 // module statically from this file.

--- a/server/state.ts
+++ b/server/state.ts
@@ -551,7 +551,11 @@ export function writeStatusState(
     xp: xpTotal,
     mood: moodStr,
   };
-  writeFileSync(STATUS_FILE(), JSON.stringify(state));
+  // Atomic: the statusline reads this file on a timer, so a plain write can
+  // be observed half-flushed and blank the companion for a tick.
+  const statusTmp = `${STATUS_FILE()}.tmp`;
+  writeFileSync(statusTmp, JSON.stringify(state));
+  renameSync(statusTmp, STATUS_FILE());
   // writeStatusState no longer calls saveReaction implicitly. Callers
   // that need a reaction file do so explicitly with the correct
   // `source` tag — the old implicit save had no source argument and

--- a/server/state.ts
+++ b/server/state.ts
@@ -30,10 +30,12 @@ import {
   rmSync,
 } from "fs";
 import { join } from "path";
-import type { Companion } from "../core/engine.ts"
+import { configuredSharedUserId } from "../core/identity.ts";
+import type { BuddyBones, Companion } from "../core/engine.ts"
 import type * as CoreEngine from "../core/engine.ts";
 import type * as Art from "./art.ts";
-import { configuredSharedUserId } from "../core/identity.ts";
+import type * as MoodModule from "./mood.ts";
+import type * as XpModule from "./xp.ts";
 import {
   buddyStateDir,
   claudeSettingsPath,
@@ -41,9 +43,17 @@ import {
   toUnixPath,
 } from "./path.ts";
 
-export const STATE_DIR = buddyStateDir();
-const MANIFEST_FILE = join(STATE_DIR, "menagerie.json");
-const CONFIG_FILE = join(STATE_DIR, "config.json");
+// Resolved per call, never captured at import. ES modules are cached, so a
+// module-level `buddyStateDir()` pinned these paths to whatever
+// CLAUDE_CONFIG_DIR happened to be at *first* import. Once any file in a test
+// process had imported this module, every later redirect was silently ignored —
+// which is how `bun test` came to overwrite a user's live companion with a test
+// fixture. Individually the test files were clean; only running them together
+// leaked. A lazy lookup makes that class of bug impossible.
+const stateDir = () => buddyStateDir();
+const MANIFEST_FILE = () => join(stateDir(), "menagerie.json");
+const CONFIG_FILE = () => join(stateDir(), "config.json");
+const STATUS_FILE = () => join(stateDir(), "status.json");
 
 // ─── Session ID (Claude Code session isolation, tmux pane fallback) ─────────
 //
@@ -65,7 +75,7 @@ function sessionId(): string {
 }
 
 function reactionFile(): string {
-  return join(STATE_DIR, `reaction.${sessionId()}.json`);
+  return join(stateDir(), `reaction.${sessionId()}.json`);
 }
 
 // ─── Manifest schema ─────────────────────────────────────────────────────────
@@ -83,7 +93,7 @@ function emptyManifest(): Manifest {
 
 function loadManifest(): Manifest {
   try {
-    const raw = readFileSync(MANIFEST_FILE, "utf8");
+    const raw = readFileSync(MANIFEST_FILE(), "utf8");
     const m = JSON.parse(raw) as Manifest;
     if (!m.companions) m.companions = {};
     return m;
@@ -93,10 +103,10 @@ function loadManifest(): Manifest {
 }
 
 function saveManifest(m: Manifest): void {
-  mkdirSync(STATE_DIR, { recursive: true });
-  const tmp = MANIFEST_FILE + ".tmp";
+  mkdirSync(stateDir(), { recursive: true });
+  const tmp = MANIFEST_FILE() + ".tmp";
   writeFileSync(tmp, JSON.stringify(m, null, 2));
-  renameSync(tmp, MANIFEST_FILE); // atomic on same filesystem
+  renameSync(tmp, MANIFEST_FILE()); // atomic on same filesystem
 }
 
 // ─── Slot helpers ────────────────────────────────────────────────────────────
@@ -222,13 +232,13 @@ export function saveCompanion(companion: Companion): void {
 // ─── Migration: legacy companion.json -> single manifest ────────────────────
 
 function migrateIfNeeded(): void {
-  if (existsSync(MANIFEST_FILE)) return;
+  if (existsSync(MANIFEST_FILE())) return;
 
   const companions: Record<string, Companion> = {};
   let active = "buddy";
 
   // Absorb menagerie/<slot>.json files
-  const menagerieDir = join(STATE_DIR, "menagerie");
+  const menagerieDir = join(stateDir(), "menagerie");
   if (existsSync(menagerieDir)) {
     try {
       for (const f of readdirSync(menagerieDir).filter((f) =>
@@ -249,7 +259,7 @@ function migrateIfNeeded(): void {
   }
 
   // Absorb legacy companion.json
-  const legacyFile = join(STATE_DIR, "companion.json");
+  const legacyFile = join(stateDir(), "companion.json");
   if (existsSync(legacyFile) && Object.keys(companions).length === 0) {
     try {
       const c: Companion = JSON.parse(readFileSync(legacyFile, "utf8"));
@@ -262,7 +272,7 @@ function migrateIfNeeded(): void {
   }
 
   // Read active pointer if it exists
-  const activeFile = join(STATE_DIR, "active");
+  const activeFile = join(stateDir(), "active");
   if (existsSync(activeFile)) {
     try {
       const a = readFileSync(activeFile, "utf8").trim();
@@ -322,7 +332,7 @@ export function saveReaction(
   reason: string,
   source: ReactionSource = "fallback",
 ): void {
-  mkdirSync(STATE_DIR, { recursive: true });
+  mkdirSync(stateDir(), { recursive: true });
   const state: ReactionState = { reaction, timestamp: Date.now(), reason, source };
   // Atomic via tmp + rename — torn reads on the reaction file would
   // make the Stop hook's freshness check see an absent file, pinning
@@ -353,6 +363,7 @@ export interface BuddyConfig {
   bubblePosition: "top" | "left";
   showRarity: boolean;
   statusLineEnabled: boolean;
+  statuslineDensity: "auto" | "full" | "compact" | "minimal";
   statuslineWidthAdjust: number;
   bubbleWidth: number;
   bubbleMargin: number;
@@ -366,7 +377,6 @@ export interface BuddyConfig {
   suggestionsEnabled: boolean;
   suggestionCooldown: number;
 }
-
 const DEFAULT_CONFIG: BuddyConfig = {
   commentCooldown: 30,
   // Long enough that a reaction survives the turn you were reading when it was
@@ -377,6 +387,7 @@ const DEFAULT_CONFIG: BuddyConfig = {
   bubblePosition: "top",
   showRarity: true,
   statusLineEnabled: false,
+  statuslineDensity: "auto",
   statuslineWidthAdjust: 0,
   bubbleWidth: 28,
   bubbleMargin: 8,
@@ -406,22 +417,26 @@ export function normalizeConfig(data: unknown): BuddyConfig {
   if (!Number.isInteger(config.statuslineWidthAdjust)) {
     config.statuslineWidthAdjust = DEFAULT_CONFIG.statuslineWidthAdjust;
   }
+  const allowedDensities: BuddyConfig["statuslineDensity"][] = ["auto", "full", "compact", "minimal"];
+  if (!allowedDensities.includes(config.statuslineDensity)) {
+    config.statuslineDensity = DEFAULT_CONFIG.statuslineDensity;
+  }
   return config;
 }
 
 export function loadConfig(): BuddyConfig {
   try {
-    return normalizeConfig(JSON.parse(readFileSync(CONFIG_FILE, "utf8")));
+    return normalizeConfig(JSON.parse(readFileSync(CONFIG_FILE(), "utf8")));
   } catch {
     return normalizeConfig({});
   }
 }
 
 export function saveConfig(config: Partial<BuddyConfig>): BuddyConfig {
-  mkdirSync(STATE_DIR, { recursive: true });
+  mkdirSync(stateDir(), { recursive: true });
   const current = loadConfig();
   const merged = { ...current, ...config };
-  writeFileSync(CONFIG_FILE, JSON.stringify(merged, null, 2));
+  writeFileSync(CONFIG_FILE(), JSON.stringify(merged, null, 2));
   return merged;
 }
 
@@ -440,12 +455,36 @@ export interface StatusState {
   muted: boolean;
   achievement: string;
   frames: string[];
+  compactFrames: string[];
+  minimalFrames: string[];
   frameSequence: number[];
   level: number;
   xp: number;
   mood: string;
 }
 
+// Density frame fallbacks used when server/art.ts has not yet been updated
+// to emit compactFrames/minimalFrames. The art worker owns the pre-rendered
+// density frames; state.ts only derives a degraded fallback from the full
+// frames so old/new status.json remains renderable.
+function deriveCompactFrames(fullFrames: string[]): string[] {
+  return fullFrames.map((body) => {
+    const lines = body.split("\n");
+    const selected: string[] = [];
+    for (const line of lines) {
+      if (selected.length >= 3) break;
+      if (line.trim() !== "") selected.push(line);
+    }
+    while (selected.length < 3) selected.push("");
+    return selected.join("\n");
+  });
+}
+
+function deriveMinimalFrames(bones: BuddyBones, eye: string): string[] {
+  const { renderFace } = require("../core/engine.ts") as typeof CoreEngine;
+  const face = renderFace(bones.species, eye);
+  return Array.from({ length: 4 }, () => face);
+}
 export function writeStatusState(
   companion: Companion,
   reaction?: string,
@@ -454,18 +493,32 @@ export function writeStatusState(
   level?: number,
   xp?: number,
 ): void {
-  mkdirSync(STATE_DIR, { recursive: true });
+  mkdirSync(stateDir(), { recursive: true });
   const { renderFace, RARITY_STARS, resolveEyeGlyph } =
     require("../core/engine.ts") as typeof CoreEngine;
   const { getStatusFrames } =
     require("./art.ts") as typeof Art;
   const safeEye = resolveEyeGlyph(companion.bones.eye);
-  const { frames, frameSequence } = getStatusFrames(companion.bones);
+  const artResult = getStatusFrames(companion.bones) as {
+    frames: string[];
+    frameSequence: number[];
+    compactFrames?: string[];
+    minimalFrames?: string[];
+  };
+  const { frames, frameSequence } = artResult;
+  const compactFrames =
+    artResult.compactFrames && artResult.compactFrames.length > 0
+      ? artResult.compactFrames
+      : deriveCompactFrames(frames);
+  const minimalFrames =
+    artResult.minimalFrames && artResult.minimalFrames.length > 0
+      ? artResult.minimalFrames
+      : deriveMinimalFrames(companion.bones, safeEye);
   let xpLevel = level ?? 1;
   let xpTotal = xp ?? 0;
   let moodStr = "focused";
   try {
-    const { getXpState } = require("./xp.ts") as typeof import("./xp.ts");
+    const { getXpState } = require("./xp.ts") as typeof XpModule;
     const xpState = getXpState();
     xpLevel = xpState.level;
     xpTotal = xpState.totalXp;
@@ -473,7 +526,7 @@ export function writeStatusState(
     // XP state is optional during first install / version skew.
   }
   try {
-    const { getMood } = require("./mood.ts") as typeof import("./mood.ts");
+    const { getMood } = require("./mood.ts") as typeof MoodModule;
     moodStr = getMood().current;
   } catch {
     // Mood state is optional during first install / version skew.
@@ -491,11 +544,14 @@ export function writeStatusState(
     muted: muted ?? false,
     achievement: achievement ?? "",
     frames,
+    compactFrames,
+    minimalFrames,
     frameSequence,
     level: xpLevel,
     xp: xpTotal,
     mood: moodStr,
   };
+  writeFileSync(STATUS_FILE(), JSON.stringify(state));
   // writeStatusState no longer calls saveReaction implicitly. Callers
   // that need a reaction file do so explicitly with the correct
   // `source` tag — the old implicit save had no source argument and
@@ -580,11 +636,11 @@ const TRANSIENT_PREFIXES = [
  *
  * Companion data (menagerie.json, status.json, config.json) is intentionally
  * kept — users reinstalling get their buddy back. Call-sites that want a full
- * wipe should delete STATE_DIR themselves after calling this.
+ * wipe should delete stateDir() themselves after calling this.
  */
 export function cleanupPluginState(
   settingsPath: string = CLAUDE_SETTINGS_PATH,
-  stateDir: string = STATE_DIR,
+  stateDir: string = buddyStateDir(),
 ): CleanupResult {
   const statusLineRemoved = unsetBuddyStatusLine(settingsPath);
 

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -16,6 +16,7 @@
 # controlling PTY after startup. Snapshot the exported value before any
 # sourced helper or external command can trigger that refresh.
 _INHERITED_COLUMNS="${COLUMNS:-}"
+_INHERITED_ROWS="${LINES:-}"
 # Width math and substring slicing must agree on UTF-8 codepoints. Claude Code
 # emits Unicode art even when a caller inherited the POSIX C locale.
 _LOCALE_HINT="${LC_ALL:-${LC_CTYPE:-${LANG:-}}}"
@@ -62,24 +63,9 @@ MOOD=$(jq -r '.mood // "focused"' "$STATE" 2>/dev/null)
 
 BUDDY_STATUSLINE_INPUT=$(cat)
 
-# ─── Animation: pick current frame from server-rendered frames ──────────────
+# ─── Animation timing ───────────────────────────────────────────────────────
 NOW=${BUDDY_FAKE_NOW:-$(date +%s)}
-FRAME_BODY=$(jq -r --argjson now "$NOW" '
-    .frameSequence[$now % (.frameSequence | length)] as $idx
-    | .frames[$idx] // ""
-' "$STATE" 2>/dev/null)
-
-# Fallback when status.json lacks .frames — e.g. server/bash version skew
-# during install or while the MCP server hasn't rewritten the file yet. Keep
-# the buddy visible in a degraded form instead of emitting an empty block.
-if [ -z "$FRAME_BODY" ]; then
-    FRAME_BODY=$'            \n    (°°)    \n    (  )    \n            \n            '
-fi
-
-ART_LINES=()
-while IFS= read -r line; do
-    ART_LINES+=("$line")
-done <<< "$FRAME_BODY"
+# The actual frame body is selected later once density/rows are known.
 
 # ─── Rarity color (theme-aware) ─────────────────────────────────────────────
 _THEME="dark"
@@ -139,7 +125,7 @@ COLOR_ENABLED=1
 RAINBOW_LEN=${#RAINBOW[@]}
 RAINBOW_OFFSET=$(( NOW % RAINBOW_LEN ))
 
-_is_positive_cols() {
+_is_positive_int() {
     case "$1" in
         ''|*[!0-9]*) return 1 ;;
     esac
@@ -147,8 +133,9 @@ _is_positive_cols() {
     return 1
 }
 
-# ─── Terminal width ──────────────────────────────────────────────────────────
+# ─── Terminal size (rows + columns from the same stty size probe) ─────────────
 COLS=0
+ROWS=0
 
 # Claude Code renders this command inside a content box, not across the full
 # terminal. Reserve two columns for settings.json padding (1 per side) and
@@ -159,18 +146,32 @@ COLS=0
 CHROME_RESERVE=14
 STATUSLINE_WIDTH_ADJUST=0
 
-# Width resolution precedence (real use):
-#   1. BUDDY_STATUSLINE_COLS (validated positive integer)
-#   2. exported COLUMNS (validated positive integer)
-#   3. Linux: /proc/$PID/fd/0 PTY via stty size
-#   4. macOS: ps + stty on /dev/$TTY_NAME
-#   5. Windows: PowerShell (Get-Host).UI.RawUI.WindowSize.Width
-#   6. final default 125
-if _is_positive_cols "${BUDDY_STATUSLINE_COLS:-}"; then
+ROWS=0
+COLS=0
+
+# Rows/cols resolution precedence (real use):
+#   1. BUDDY_STATUSLINE_ROWS / BUDDY_STATUSLINE_COLS (validated positive ints)
+#   2. exported LINES / COLUMNS (validated positive ints)
+#   3. Linux: /proc/$PID/fd/0 PTY via stty size (captures both values)
+#   4. macOS: ps + stty on /dev/$TTY_NAME (captures both values)
+#   5. Windows: PowerShell (Get-Host).UI.RawUI.WindowSize.Height/Width
+#   6. final defaults: ROWS 999 (full), COLS 125
+if _is_positive_int "${BUDDY_STATUSLINE_ROWS:-}"; then
+    ROWS=$((10#${BUDDY_STATUSLINE_ROWS}))
+elif _is_positive_int "$_INHERITED_ROWS"; then
+    ROWS=$((10#$_INHERITED_ROWS))
+fi
+
+if _is_positive_int "${BUDDY_STATUSLINE_COLS:-}"; then
     COLS=$((10#${BUDDY_STATUSLINE_COLS}))
-elif _is_positive_cols "$_INHERITED_COLUMNS"; then
+elif _is_positive_int "$_INHERITED_COLUMNS"; then
     COLS=$((10#$_INHERITED_COLUMNS))
-else
+fi
+
+# If either dimension is still unknown, walk the process tree and read the
+# PTY dimensions once. stty size returns "rows cols"; parse both from the same
+# probe so rows and cols are consistent and no extra detection pass is needed.
+if [ "$ROWS" -lt 1 ] 2>/dev/null || [ "$COLS" -lt 1 ] 2>/dev/null; then
     PID=$$
     for _ in 1 2 3 4 5; do
         PID=$(ps -o ppid= -p "$PID" 2>/dev/null | tr -d ' ')
@@ -179,8 +180,14 @@ else
         # Linux: read PTY device from /proc
         PTY=$(readlink "/proc/${PID}/fd/0" 2>/dev/null)
         if [ -c "$PTY" ] 2>/dev/null; then
-            COLS=$(stty size < "$PTY" 2>/dev/null | awk '{print $2}')
-            _is_positive_cols "${COLS:-}" && break
+            _stty=$(stty size < "$PTY" 2>/dev/null)
+            if [ -n "$_stty" ]; then
+                _rows=${_stty%% *}
+                _cols=${_stty##* }
+                [ "$ROWS" -lt 1 ] 2>/dev/null && _is_positive_int "$_rows" && ROWS=$((10#$_rows))
+                [ "$COLS" -lt 1 ] 2>/dev/null && _is_positive_int "$_cols" && COLS=$((10#$_cols))
+                [ "$ROWS" -gt 0 ] 2>/dev/null && [ "$COLS" -gt 0 ] 2>/dev/null && break
+            fi
         fi
 
         # macOS: /proc doesn't exist — get TTY name from process table
@@ -188,24 +195,38 @@ else
         if [ -n "$TTY_NAME" ] && [ "$TTY_NAME" != "??" ] && [ "$TTY_NAME" != "?" ]; then
             TTY_DEV="/dev/$TTY_NAME"
             if [ -c "$TTY_DEV" ] 2>/dev/null; then
-                COLS=$(stty size < "$TTY_DEV" 2>/dev/null | awk '{print $2}')
-                _is_positive_cols "${COLS:-}" && break
+                _stty=$(stty size < "$TTY_DEV" 2>/dev/null)
+                if [ -n "$_stty" ]; then
+                    _rows=${_stty%% *}
+                    _cols=${_stty##* }
+                    [ "$ROWS" -lt 1 ] 2>/dev/null && _is_positive_int "$_rows" && ROWS=$((10#$_rows))
+                    [ "$COLS" -lt 1 ] 2>/dev/null && _is_positive_int "$_cols" && COLS=$((10#$_cols))
+                    [ "$ROWS" -gt 0 ] 2>/dev/null && [ "$COLS" -gt 0 ] 2>/dev/null && break
+                fi
             fi
         fi
     done
-
-    [ "${COLS:-0}" -lt 1 ] 2>/dev/null && COLS=0
-    # Windows: /proc and TTY device detection don't exist; use PowerShell as fallback
-    if [ "${COLS:-0}" -lt 1 ] 2>/dev/null; then
-        _ps_cols=$(powershell.exe -NoProfile -Command "(Get-Host).UI.RawUI.WindowSize.Width" 2>/dev/null | tr -d '\r\n')
-        if _is_positive_cols "$_ps_cols"; then
-            [ "$_ps_cols" -gt 40 ] 2>/dev/null && COLS=$((10#$_ps_cols))
-        fi
-    fi
-    [ "${COLS:-0}" -lt 1 ] 2>/dev/null && COLS=125
 fi
+
+[ "${COLS:-0}" -lt 1 ] 2>/dev/null && COLS=0
+# Windows: /proc and TTY device detection don't exist; use PowerShell as fallback
+if [ "${COLS:-0}" -lt 1 ] 2>/dev/null; then
+    _ps_cols=$(powershell.exe -NoProfile -Command "(Get-Host).UI.RawUI.WindowSize.Width" 2>/dev/null | tr -d '\r\n')
+    if _is_positive_int "$_ps_cols"; then
+        [ "$_ps_cols" -gt 40 ] 2>/dev/null && COLS=$((10#$_ps_cols))
+    fi
+fi
+if [ "${ROWS:-0}" -lt 1 ] 2>/dev/null; then
+    _ps_rows=$(powershell.exe -NoProfile -Command "(Get-Host).UI.RawUI.WindowSize.Height" 2>/dev/null | tr -d '\r\n')
+    _is_positive_int "$_ps_rows" && ROWS=$((10#$_ps_rows))
+fi
+
+[ "${COLS:-0}" -lt 1 ] 2>/dev/null && COLS=125
+[ "${ROWS:-0}" -lt 1 ] 2>/dev/null && ROWS=999
+
 COLS=$((10#$COLS))
 DETECTED_COLS="$COLS"
+DETECTED_ROWS="$ROWS"
 
 # ─── Reaction bubble (with TTL check) ────────────────────────────────────────
 BUBBLE=""
@@ -215,6 +236,7 @@ fi
 REACTION_TTL=900
 INNER_W=44
 MARGIN=8
+DENSITY="auto"
 if [ -f "$CONFIG_FILE" ]; then
     _ttl=$(jq -r '.reactionTTL // 900' "$CONFIG_FILE" 2>/dev/null || echo 900)
     case "$_ttl" in ''|*[!0-9]*) ;; *) REACTION_TTL="$_ttl" ;; esac
@@ -230,7 +252,34 @@ if [ -f "$CONFIG_FILE" ]; then
             *)  STATUSLINE_WIDTH_ADJUST=$((10#$_wa)) ;;
         esac
     fi
+    _density=$(jq -r '.statuslineDensity // "auto"' "$CONFIG_FILE" 2>/dev/null || echo "auto")
+    case "$_density" in
+        auto|full|compact|minimal) DENSITY="$_density" ;;
+        *) DENSITY="auto" ;;
+    esac
 fi
+# ─── Statusline density tier ─────────────────────────────────────────────────
+# Explicit config/env density overrides pin the tier; otherwise rows drive it:
+#   full >= 40, compact 20-39, minimal < 20. Very narrow terminals also force minimal.
+if [ -n "${BUDDY_STATUSLINE_DENSITY:-}" ]; then
+    DENSITY="${BUDDY_STATUSLINE_DENSITY}"
+fi
+case "$DENSITY" in
+    full|compact|minimal) TIER="$DENSITY" ;;
+    *)
+        TIER="full"
+        if [ "$DETECTED_ROWS" -lt 40 ] 2>/dev/null; then
+            TIER="compact"
+        fi
+        if [ "$DETECTED_ROWS" -lt 20 ] 2>/dev/null; then
+            TIER="minimal"
+        fi
+        if [ "$DETECTED_COLS" -lt 40 ] 2>/dev/null; then
+            TIER="minimal"
+        fi
+        ;;
+esac
+
 _sweep_expired_reactions() {
     [ "$REACTION_TTL" -gt 0 ] 2>/dev/null || return 0
     local now cutoff_ms cutoff_seconds file ts
@@ -281,6 +330,28 @@ if [ -n "$REACTION" ] && [ "$REACTION" != "null" ] && [ "$REACTION" != "" ]; the
         rm -f "$REACTION_FILE" 2>/dev/null
     fi
 fi
+
+# ─── Animation: pick current density frame from server-rendered frames ───────
+NOW=${BUDDY_FAKE_NOW:-$(date +%s)}
+FRAME_BODY=$(jq -r --argjson now "$NOW" --arg tier "$TIER" '
+    .frameSequence[$now % (.frameSequence | length)] as $idx
+    | if $tier == "compact" then ((.compactFrames? // .frames) | .[$idx] // .frames[$idx])
+      elif $tier == "minimal" then ((.minimalFrames? // .frames) | .[$idx] // .frames[$idx])
+      else .frames[$idx]
+      end // ""
+' "$STATE" 2>/dev/null)
+
+# Fallback when status.json lacks .frames — e.g. server/bash version skew
+# during install or while the MCP server hasn't rewritten the file yet. Keep
+# the buddy visible in a degraded form instead of emitting an empty block.
+if [ -z "$FRAME_BODY" ]; then
+    FRAME_BODY=$'            \n    (°°)    \n    (  )    \n            \n            '
+fi
+
+ART_LINES=()
+while IFS= read -r line; do
+    ART_LINES+=("$line")
+done <<< "$FRAME_BODY"
 
 # ─── Build all art lines ──────────────────────────────────────────────────────
 # ART_LINES comes from the pre-rendered frame (already includes hat + blink).
@@ -478,6 +549,44 @@ if [ "$STATUSLINE_BUDGET" -lt "$ART_W" ]; then
 fi
 COLS="$STATUSLINE_BUDGET"
 
+# ─── Density branch: compact drops the bubble; minimal is a single line. ─────
+if [ "$TIER" = "minimal" ]; then
+    _face_plain="${ART_LINES[0]:-}"
+    if [ -z "$_face_plain" ]; then
+        for _fline in "${ART_LINES[@]}"; do
+            [ -n "$_fline" ] && _face_plain="$_fline" && break
+        done
+    fi
+    [ -z "$_face_plain" ] && _face_plain=$'    (°°)    '
+    _min_plain="${_face_plain} ${NAME_WITH_LEVEL}"
+    _min_w=$(dwidth "$_min_plain")
+    if [ -n "$REACTION" ]; then
+        _react_plain=" │ \"${REACTION}\""
+        _react_w=$(dwidth "$_react_plain")
+        if [ $((_min_w + _react_w)) -le "$STATUSLINE_BUDGET" ]; then
+            _min_plain="${_min_plain}${_react_plain}"
+            _min_w=$(dwidth "$_min_plain")
+        fi
+    fi
+    if [ "$STATUSLINE_BUDGET" -lt "$_min_w" ]; then
+        STATUSLINE_BUDGET="$DETECTED_COLS"
+    fi
+    if [ "$STATUSLINE_BUDGET" -lt "$_min_w" ]; then
+        STATUSLINE_BUDGET=125
+    fi
+    COLS="$STATUSLINE_BUDGET"
+    ART_LINES=("$_min_plain")
+    ALL_COLORS=("$C")
+    ALL_LINES=("$_min_plain")
+    ART_COUNT=1
+    ART_W="$_min_w"
+    BUBBLE=""
+    BUBBLE_TEXT=""
+elif [ "$TIER" = "compact" ]; then
+    BUBBLE=""
+    BUBBLE_TEXT=""
+fi
+
 # The bubble, tail, and sprite are one unit. At narrow widths, drop the
 # bubble rather than allowing a partial border or tail to escape the panel.
 MIN_BUBBLE_INNER=12
@@ -556,6 +665,14 @@ case "$(uname -s)" in
     MINGW*|CYGWIN*|MSYS*) SPACER=$(printf '%*s' "$PAD" '') ;;
     *)                     SPACER=$(printf "${B}%${PAD}s" "") ;;
 esac
+
+# Minimal tier uses plain spaces so the one-line sprite + name fits without
+# sacrificing a Braille Blank column on narrow terminals.
+if [ "$TIER" = "minimal" ]; then
+    PAD=$(( COLS - ART_W ))
+    [ "$PAD" -lt 0 ] && PAD=0
+    SPACER=$(printf '%*s' "$PAD" '')
+fi
 
 # Vertically center bubble box on the art
 BUBBLE_START=0

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -571,8 +571,11 @@ if [ "$TIER" = "minimal" ]; then
     if [ "$STATUSLINE_BUDGET" -lt "$_min_w" ]; then
         STATUSLINE_BUDGET="$DETECTED_COLS"
     fi
+    # Never widen past the real terminal: a hard-coded fallback here would
+    # defeat ansi_truncate below and emit rows wider than the pane, wrapping
+    # and clobbering the prompt on genuinely narrow terminals.
     if [ "$STATUSLINE_BUDGET" -lt "$_min_w" ]; then
-        STATUSLINE_BUDGET=125
+        STATUSLINE_BUDGET="$DETECTED_COLS"
     fi
     COLS="$STATUSLINE_BUDGET"
     ART_LINES=("$_min_plain")

--- a/statusline/buddy-status.test.ts
+++ b/statusline/buddy-status.test.ts
@@ -51,7 +51,7 @@ function runStatusline(
       CLAUDE_CONFIG_DIR: configDir,
       CLAUDE_CODE_SESSION_ID: "",
       TMUX_PANE: "",
-      BUDDY_FAKE_NOW: "0",
+      BUDDY_STATUSLINE_ROWS: "50",
       BUDDY_STATUSLINE_COLS: columns,
       TERM: "xterm-256color",
       NO_COLOR: "",
@@ -465,5 +465,118 @@ describe("buddy sub-status cache", () => {
     }));
     expect(runStatusline(configDir).status).toBe(0);
     await waitFor(() => readFileSync(cacheFile, "utf8") === "refreshed");
+  });
+});
+
+describe("statusline density", () => {
+  function createDensityFixture(
+    density: string,
+    overrides: Record<string, unknown> = {},
+    statusOverrides: Record<string, unknown> = {},
+  ) {
+    const { configDir, stateDir } = createStatuslineFixture({
+      statuslineDensity: density,
+      ...overrides,
+    });
+    writeFileSync(join(stateDir, "status.json"), JSON.stringify({
+      name: "Nimbus",
+      rarity: "common",
+      stars: "",
+      shiny: false,
+      reaction: (statusOverrides.reaction as string) ?? "",
+      achievement: "",
+      level: 1,
+      mood: "focused",
+      frames: statusOverrides.frames ?? ["l0\nl1\nl2\nl3\nl4"],
+      compactFrames: statusOverrides.compactFrames ?? ["c0\nc1\nc2"],
+      minimalFrames: statusOverrides.minimalFrames ?? ["face"],
+      frameSequence: [0],
+    }));
+    return { configDir, stateDir };
+  }
+
+
+  test("auto tier selects full when rows >= 40", () => {
+    const { configDir } = createDensityFixture("auto");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "50" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBeGreaterThanOrEqual(6);
+    expect(result.stdout.toString()).toContain("Nimbus");
+  });
+
+  test("auto tier selects compact when rows are 20-39", () => {
+    const { configDir } = createDensityFixture("auto");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "30" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBe(4);
+    expect(result.stdout.toString()).toContain("Nimbus");
+  });
+
+  test("auto tier selects minimal when rows < 20", () => {
+    const { configDir } = createDensityFixture("auto");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "10" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBe(1);
+    expect(result.stdout.toString()).toContain("Nimbus");
+  });
+
+  test("auto tier selects minimal for very narrow terminal width", () => {
+    const { configDir } = createDensityFixture("auto");
+    const result = runStatusline(configDir, "{}\n", "30", { BUDDY_STATUSLINE_ROWS: "50" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBe(1);
+    expect(result.stdout.toString()).toContain("Nimbus");
+  });
+
+  test("BUDDY_STATUSLINE_ROWS overrides PTY rows and pins compact", () => {
+    const { configDir } = createDensityFixture("auto");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "25" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBe(4);
+  });
+
+  test("explicit full overrides row-driven minimal", () => {
+    const { configDir } = createDensityFixture("full");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "10" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBeGreaterThanOrEqual(6);
+  });
+
+  test("explicit compact overrides row-driven full", () => {
+    const { configDir } = createDensityFixture("compact");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "50" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBe(4);
+  });
+
+  test("explicit minimal overrides row-driven full", () => {
+    const { configDir } = createDensityFixture("minimal");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "50" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBe(1);
+  });
+
+  test("invalid density config falls back to auto behavior", () => {
+    const { configDir } = createDensityFixture("banana");
+    const result = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "30" });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString().split("\n").filter((line) => line.trim().length > 0).length).toBe(4);
+  });
+
+  test("minimal shows reaction only when it fits", () => {
+    const { configDir, stateDir } = createDensityFixture("minimal", {}, {
+      minimalFrames: ["(°°)"],
+    });
+    writeFileSync(join(stateDir, "reaction.default.json"), JSON.stringify({
+      reaction: "long-reaction-text",
+      timestamp: 9999999999999,
+      reason: "tool",
+    }));
+    const wide = runStatusline(configDir, "{}\n", "80", { BUDDY_STATUSLINE_ROWS: "10" });
+    expect(wide.stdout.toString()).toContain("long-reaction-text");
+
+    const narrow = runStatusline(configDir, "{}\n", "20", { BUDDY_STATUSLINE_ROWS: "10" });
+    expect(narrow.stdout.toString()).toContain("Nimbus");
+    expect(narrow.stdout.toString()).not.toContain("long-reaction-text");
   });
 });


### PR DESCRIPTION
Refs #162, #163.

## 1. Responsive density (#162)

Terminal **rows** now drive how much of the card is drawn, not just columns. The renderer already dropped the bubble as a unit when it could not fit horizontally; this is the same idea on the vertical axis.

Measured from a live iPhone mosh session into the Mac mini:

```
PTY size = 30 rows x 62 cols     (desktop is typically 50-60 rows)
```

A 6-line card is a fifth of that screen.

**Keyed on size, not transport.** `MOSH_SERVER_*` and `SSH_*` are present and detectable, but keying on them is wrong — mosh from a laptop with a large terminal would collapse needlessly, and a small local split would stay full-size. Terminal size is the honest cause.

Adds `statuslineDensity` (`auto` | `full` | `compact` | `minimal`) with validation. Rows come from the **existing** `stty size` probe, which already returned them and discarded the row count — no second detection pass, no extra subprocesses.

## 2. bun test v1.3.9 (cf6cdbbb) was overwriting the user's live companion 🐛

Found while investigating why the maintainer's pet kept turning into a duck.

`server/state.ts` captured its paths at **import time**, and ES modules are cached. Once any file in a test process imported the module, every later `CLAUDE_CONFIG_DIR` redirect was silently ignored — including the dynamic `await import("./state.ts")` in `state.test.ts`, whose comment claimed it would "re-import after env set so the module's STATE_DIR picks it up". It returned the cached instance pointed at the real state dir.

**Individually every test file was clean; only running them together leaked** — which is exactly why it went unnoticed. Anyone running `bun test` had their live companion replaced by this repo's test fixture.

Paths are now resolved per call, so the class of bug is impossible rather than merely fixed. `state.test.ts` also redirects before its first import and no longer imports the module statically.

Also fixes three symbols used without imports (`getRarityColor`, `configuredSharedUserId`, and the `HAT_ART` re-export) that broke `typecheck`.

## Verification

```
bun test                          462 pass, 0 fail
bun run typecheck                 clean
scripts/ci/check-statusline.sh    OK: all statusline golden assertions passed
statusline @ COLUMNS=93           0.46s / 0.47s / 0.73s
```

**Leak specifically verified:** a full 462-test run against a live state dir leaves the companion unchanged. Before the fix the same experiment replaced it with the fixture.

## Not included

The per-species art redesign for compact/minimal is **not in this PR**. `core/art-data.ts` is untouched — the density tiers currently reuse the existing frames. Designing 3-line and 1-line art for all 20 species is follow-up work; shipping sliced-down full sprites would produce decapitated animals, so it was deliberately left out rather than faked.

🤖 *This content was generated with AI assistance using Claude Opus 5.*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add responsive density tiers to statusline and fix test state isolation in `state.ts`
> - [`buddy-status.sh`](https://github.com/ramarivera/coding-buddy/pull/164/files#diff-afdc23429fa85d195cc34b952267092d8183d17ba78d46eb4822b31eef4e6915) now renders in three tiers — full (multi-line art + bubble), compact (3 art rows, no bubble), or minimal (single face + name, optional inline reaction) — selected based on terminal rows/cols, a `statuslineDensity` config field, or a `BUDDY_STATUSLINE_DENSITY` env override.
> - [`server/state.ts`](https://github.com/ramarivera/coding-buddy/pull/164/files#diff-8f67a258c240b7981089a0265470657058e14acfcaed30b4a5407412a92c423f) lazily resolves all file paths (state dir, config, manifest, status) per-call instead of capturing them at import time, so `CLAUDE_CONFIG_DIR` changes within a process are respected; this was the root cause of tests clobbering live companion state.
> - [`server/art.ts`](https://github.com/ramarivera/coding-buddy/pull/164/files#diff-ec0eb7012c39800a11ac29b40740765fd17fc922cf8be775c217b56f47ce648b) and [`writeStatusState`](https://github.com/ramarivera/coding-buddy/pull/164/files#diff-8f67a258c240b7981089a0265470657058e14acfcaed30b4a5407412a92c423f) now include `compactFrames` and `minimalFrames` in `status.json`, written atomically to avoid torn reads.
> - CI in [`check-statusline.sh`](https://github.com/ramarivera/coding-buddy/pull/164/files#diff-15aa5642b45dfade71da44894007365acf16e9175357b12bc5c36182d6129b80) now validates output across a rows/cols/density matrix instead of treating narrow terminals as a special case.
> - Behavioral Change: `status.json` gains two new frame arrays; terminals with fewer than 20 rows default to minimal tier and fewer than 40 cols also trigger minimal regardless of row count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5d3217.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->