### PR TITLE
chore: release 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramarivera/coding-buddy",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi",
   "type": "module",
   "omp": {


### PR DESCRIPTION
Publishes the two changes merged since `0.9.0`. Without a bump the publish workflow runs but releases nothing — `main` and npm are both on `0.9.0`, so #164 and #165 are currently unshipped.

## What ships

**#164 — responsive statusline density, and a state-clobbering fix**

Terminal rows now drive how much of the card is drawn (a 6-line card was a fifth of the screen on a 30-row phone session). More importantly it fixes a bug where **`bun test` overwrote the user's live companion with a test fixture**: `server/state.ts` captured its paths at import time, ES modules are cached, so once any test file imported it every later `CLAUDE_CONFIG_DIR` redirect was ignored. Individually the test files were clean; only running them together leaked.

**#165 — drop the postinstall lifecycle script**

It only ran `bun --version` and printed a warning, but cost every consumer an ignore-scripts warning on install.

## Why patch, not minor

Both changes are additive and backward compatible.

More practically: consumers pin `^0.9.0`, and under 0.x semantics that resolves to `>=0.9.0 <0.10.0`. A `0.10.0` would **not** be picked up — every harness would silently sit on `0.9.0` until each pin was updated by hand and re-synced. `0.9.1` is collected automatically.

🤖 *This content was generated with AI assistance using Claude Opus 5.*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.9.1
> Bumps the version field in [package.json](https://github.com/ramarivera/coding-buddy/pull/166/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.9.0` to `0.9.1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15981af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->