### PR TITLE
chore: release 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramarivera/coding-buddy",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi",
   "type": "module",
   "omp": {


### PR DESCRIPTION
Ships the reaction-pipeline fixes from #168 — the ones that explain why reactions kept appearing as canned text no matter how many times the inference path was fixed.

## What ships

- **Cross-session adoption.** The MCP server resolves `BUDDY_SID` once at launch; the hook and statusline resolve it per invocation. When they diverge, `buddy_react` wrote a real model-authored reaction into a file nothing rendered, and the hook — finding nothing fresh in *its* session — correctly fell back to the pool. Fresh tool reactions are now found across session files and adopted into the current one.

- **Hook registrations no longer accumulate.** The dedupe filter matched `coding-buddy`/`claude-buddy`, but the installed path is `<state>/app/hooks/buddy-comment.sh` — neither string appears, so every install appended another pair. A dogfooding machine reached **eight** `Stop` entries. Duplicates are not cosmetic: the first invocation adopts the reaction and stamps the marker, the rest judge it stale and overwrite the bubble. Last write wins, so the user always saw canned text.

- **Same-turn grace window**, so duplicate invocations cannot demote a reaction the first one just adopted.

- **Adoption bounded by the statusline's reaction TTL**, so a stale cross-session reaction cannot surface on a new session's first turn. Flagged independently by Devin, Copilot and CodeRabbit.

- **Test determinism:** four statusline tests pinned columns but not rows. Once density keyed on rows those became environment-dependent — red on a 30-row developer terminal, structurally invisible in CI where no tty exists.

## Why patch

Consumers pin `^0.9.0`, which under 0.x resolves to `>=0.9.0 <0.10.0`. A minor would strand every harness until each pin was updated by hand.

🤖 *This content was generated with AI assistance using Claude Opus 5.*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.9.2
> Bumps the version field in [package.json](https://github.com/ramarivera/coding-buddy/pull/169/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.9.1` to `0.9.2`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0815554.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->