### PR TITLE
fix(statusline): expire the achievement banner instead of latching it

### DIFF
--- a/server/state.ts
+++ b/server/state.ts
@@ -454,6 +454,10 @@ export interface StatusState {
   reaction: string;
   muted: boolean;
   achievement: string;
+  /** Epoch ms the achievement was awarded; 0 when none. The statusline expires
+   *  the trophy banner on this, otherwise it latches into the shared
+   *  status.json and pins every session's bubble to the last unlock. */
+  achievementAt: number;
   frames: string[];
   compactFrames: string[];
   minimalFrames: string[];
@@ -543,6 +547,7 @@ export function writeStatusState(
     reaction: "",
     muted: muted ?? false,
     achievement: achievement ?? "",
+    achievementAt: achievement ? Date.now() : 0,
     frames,
     compactFrames,
     minimalFrames,

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -315,14 +315,20 @@ _sweep_expired_reactions
 # alongside the name by writeStatusState. A legacy status.json without the field
 # (pre-upgrade, or a snapshot fixture) is treated as fresh — the next write from
 # the server backfills it.
+#
+# Validity and age are separate gates on purpose. A zeroed or malformed
+# achievementAt means "nothing pending" and must never render, including under
+# reactionTTL=0 — that opt-out disables *expiry*, not the field's meaning.
 if [ -n "$ACHIEVEMENT" ] && [ "$ACHIEVEMENT" != "null" ]; then
     ACH_FRESH=1
-    if [ "$REACTION_TTL" -gt 0 ] 2>/dev/null && [ "$ACHIEVEMENT_AT" != "absent" ]; then
+    if [ "$ACHIEVEMENT_AT" != "absent" ]; then
         case "$ACHIEVEMENT_AT" in
-            ''|*[!0-9]*) ACH_FRESH=0 ;;
+            ''|0|*[!0-9]*) ACH_FRESH=0 ;;
             *)
-                ACH_AGE=$(( ($(date +%s) * 1000 - ACHIEVEMENT_AT) / 1000 ))
-                [ "$ACH_AGE" -ge "$REACTION_TTL" ] && ACH_FRESH=0
+                if [ "$REACTION_TTL" -gt 0 ] 2>/dev/null; then
+                    ACH_AGE=$(( ($(date +%s) * 1000 - ACHIEVEMENT_AT) / 1000 ))
+                    [ "$ACH_AGE" -ge "$REACTION_TTL" ] && ACH_FRESH=0
+                fi
                 ;;
         esac
     fi

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -58,6 +58,9 @@ STARS=$(jq -r '.stars // ""' "$STATE" 2>/dev/null)
 SHINY=$(jq -r '.shiny // false' "$STATE" 2>/dev/null)
 REACTION_FILE="$BUDDY_STATE_DIR/reaction.$SID.json"
 ACHIEVEMENT=$(jq -r '.achievement // ""' "$STATE" 2>/dev/null)
+# "absent" distinguishes a legacy status.json (no field at all) from an explicit
+# 0, which means "no achievement pending" and must not render.
+ACHIEVEMENT_AT=$(jq -r 'if has("achievementAt") then (.achievementAt // 0) else "absent" end' "$STATE" 2>/dev/null)
 LEVEL=$(jq -r '.level // 1' "$STATE" 2>/dev/null)
 MOOD=$(jq -r '.mood // "focused"' "$STATE" 2>/dev/null)
 
@@ -229,10 +232,10 @@ DETECTED_COLS="$COLS"
 DETECTED_ROWS="$ROWS"
 
 # ─── Reaction bubble (with TTL check) ────────────────────────────────────────
+# The achievement banner is resolved further down, once REACTION_TTL is known —
+# it expires on the same clock as a reaction. Without that it latches into the
+# shared status.json and pins every session's bubble to the last trophy.
 BUBBLE=""
-if [ -n "$ACHIEVEMENT" ] && [ "$ACHIEVEMENT" != "null" ] && [ "$ACHIEVEMENT" != "" ]; then
-    BUBBLE=$'\xf0\x9f\x8f\x86'" $ACHIEVEMENT"
-fi
 REACTION_TTL=900
 INNER_W=44
 MARGIN=8
@@ -307,6 +310,25 @@ _sweep_expired_reactions() {
 }
 
 _sweep_expired_reactions
+
+# Achievement banner: shown only while fresh. ACHIEVEMENT_AT is epoch ms, written
+# alongside the name by writeStatusState. A legacy status.json without the field
+# (pre-upgrade, or a snapshot fixture) is treated as fresh — the next write from
+# the server backfills it.
+if [ -n "$ACHIEVEMENT" ] && [ "$ACHIEVEMENT" != "null" ]; then
+    ACH_FRESH=1
+    if [ "$REACTION_TTL" -gt 0 ] 2>/dev/null && [ "$ACHIEVEMENT_AT" != "absent" ]; then
+        case "$ACHIEVEMENT_AT" in
+            ''|*[!0-9]*) ACH_FRESH=0 ;;
+            *)
+                ACH_AGE=$(( ($(date +%s) * 1000 - ACHIEVEMENT_AT) / 1000 ))
+                [ "$ACH_AGE" -ge "$REACTION_TTL" ] && ACH_FRESH=0
+                ;;
+        esac
+    fi
+    [ "$ACH_FRESH" -eq 1 ] && BUBBLE=$'\xf0\x9f\x8f\x86'" $ACHIEVEMENT"
+fi
+
 REACTION=$(jq -r '.reaction // ""' "$REACTION_FILE" 2>/dev/null)
 if [ -n "$REACTION" ] && [ "$REACTION" != "null" ] && [ "$REACTION" != "" ]; then
     FRESH=0

--- a/statusline/buddy-status.test.ts
+++ b/statusline/buddy-status.test.ts
@@ -584,3 +584,63 @@ describe("statusline density", () => {
     expect(narrow.stdout.toString()).not.toContain("long-reaction-text");
   });
 });
+
+describe("achievement banner expiry", () => {
+  function writeStatus(stateDir: string, extra: Record<string, unknown>) {
+    writeFileSync(join(stateDir, "status.json"), JSON.stringify({
+      name: "Nimbus",
+      rarity: "common",
+      stars: "★",
+      shiny: false,
+      reaction: "",
+      level: 1,
+      mood: "focused",
+      frames: ["  art"],
+      frameSequence: [0],
+      ...extra,
+    }));
+  }
+
+  test("shows a freshly awarded achievement", () => {
+    const { configDir, stateDir } = createStatuslineFixture({ reactionTTL: 900 });
+    writeStatus(stateDir, { achievement: "🕊️ Diplomat", achievementAt: Date.now() });
+
+    const result = runStatusline(configDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString()).toContain("Diplomat");
+  });
+
+  test("drops an achievement older than the reaction TTL", () => {
+    const { configDir, stateDir } = createStatuslineFixture({ reactionTTL: 900 });
+    writeStatus(stateDir, {
+      achievement: "🕊️ Diplomat",
+      achievementAt: Date.now() - 901_000,
+    });
+
+    const result = runStatusline(configDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString()).not.toContain("Diplomat");
+  });
+
+  test("does not render a banner when achievementAt is zeroed", () => {
+    const { configDir, stateDir } = createStatuslineFixture({ reactionTTL: 900 });
+    writeStatus(stateDir, { achievement: "🕊️ Diplomat", achievementAt: 0 });
+
+    const result = runStatusline(configDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString()).not.toContain("Diplomat");
+  });
+
+  test("treats a legacy status.json without achievementAt as fresh", () => {
+    const { configDir, stateDir } = createStatuslineFixture({ reactionTTL: 900 });
+    writeStatus(stateDir, { achievement: "🕊️ Diplomat" });
+
+    const result = runStatusline(configDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString()).toContain("Diplomat");
+  });
+});

--- a/statusline/buddy-status.test.ts
+++ b/statusline/buddy-status.test.ts
@@ -634,6 +634,29 @@ describe("achievement banner expiry", () => {
     expect(result.stdout.toString()).not.toContain("Diplomat");
   });
 
+  test("never renders a zeroed achievementAt even when reactionTTL disables expiry", () => {
+    const { configDir, stateDir } = createStatuslineFixture({ reactionTTL: 0 });
+    writeStatus(stateDir, { achievement: "\u{1F54A}\uFE0F Diplomat", achievementAt: 0 });
+
+    const result = runStatusline(configDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString()).not.toContain("Diplomat");
+  });
+
+  test("reactionTTL=0 keeps a validly stamped achievement from expiring", () => {
+    const { configDir, stateDir } = createStatuslineFixture({ reactionTTL: 0 });
+    writeStatus(stateDir, {
+      achievement: "\u{1F54A}\uFE0F Diplomat",
+      achievementAt: Date.now() - 86_400_000,
+    });
+
+    const result = runStatusline(configDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString()).toContain("Diplomat");
+  });
+
   test("treats a legacy status.json without achievementAt as fresh", () => {
     const { configDir, stateDir } = createStatuslineFixture({ reactionTTL: 900 });
     writeStatus(stateDir, { achievement: "🕊️ Diplomat" });


### PR DESCRIPTION
## The bug

The trophy banner rendered unconditionally from `status.json` with **no TTL**, while reactions expire via `_sweep_expired_reactions`. `status.json` is shared across all sessions (reactions are per-SID), so a single unlock pinned *every* session's bubble to that achievement until some path happened to call `writeStatusState` with no achievement.

Observed live: `conflict_resolver` ("Diplomat") unlocked at `1785186841582` and the banner was still pinned ~5h later.

## The fix

- `server/state.ts` — `StatusState` gains `achievementAt`, stamped on write, `0` when there is no achievement.
- `statusline/buddy-status.sh` — the banner expires on the same `reactionTTL` clock as a reaction. The block moved below the config load since it needs `REACTION_TTL`.

Compatibility: an explicit `0` never renders; a legacy `status.json` with no `achievementAt` at all is treated as fresh and self-heals on the next server write, so existing snapshot fixtures are unaffected.

## Tests

4 new cases in `statusline/buddy-status.test.ts`: fresh shows, older-than-TTL drops, zeroed drops, legacy-missing-field shows.

`bun test` → **469 pass, 0 fail**.

🤖 *Created with the help of AI (Claude Opus 5).*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expire the achievement banner in the statusline after `REACTION_TTL` seconds
> - The achievement banner previously latched indefinitely once set; it now expires after `REACTION_TTL` seconds by comparing the current time against a new `achievementAt` epoch timestamp stored in `status.json`.
> - [server/state.ts](https://github.com/ramarivera/coding-buddy/pull/170/files#diff-8f67a258c240b7981089a0265470657058e14acfcaed30b4a5407412a92c423f) writes `achievementAt` as `Date.now()` when an achievement is present, or `0` when absent.
> - [statusline/buddy-status.sh](https://github.com/ramarivera/coding-buddy/pull/170/files#diff-afdc23429fa85d195cc34b952267092d8183d17ba78d46eb4822b31eef4e6915) reads `achievementAt` and suppresses the banner if its age (in seconds) meets or exceeds `REACTION_TTL`; setting `REACTION_TTL=0` disables expiry for validly stamped achievements.
> - Legacy `status.json` files without `achievementAt` treat the achievement as fresh to preserve backward compatibility.
> - Behavioral Change: a zero or malformed `achievementAt` now suppresses the banner entirely, regardless of `REACTION_TTL`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee7ad8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->