### PR TITLE
chore: release 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramarivera/coding-buddy",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi",
   "type": "module",
   "omp": {


### PR DESCRIPTION
Version-only bump. Ships the achievement-banner expiry fix from #170.

The trophy banner rendered from the shared `status.json` with no TTL while reactions expire on a sweep, so a single unlock pinned *every* session's bubble until some path happened to call `writeStatusState` with no achievement — observed live as a "Diplomat" banner stuck for ~5h.

`writeStatusState` now stamps `achievementAt` and the statusline expires the banner on the same `reactionTTL` clock as a reaction. Validity and age are separate gates: a zeroed or malformed stamp never renders regardless of TTL, and `reactionTTL=0` disables expiry only.

Note: `.claude-plugin/plugin.json` and `marketplace.json` still read `0.8.0`. That drift predates this release and is what #110 is for — deliberately not touched here.

🤖 *Created with the help of AI (Claude Opus 5).*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.9.3
> Bumps the package version from `0.9.2` to `0.9.3` in [package.json](https://github.com/ramarivera/coding-buddy/pull/172/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5916ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->