### PR TITLE
chore: sync plugin and MCP version fields to 0.9.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     },
     "metadata": {
         "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi (requires bun: https://bun.sh/install)",
-        "version": "0.8.0"
+        "version": "0.9.3"
     },
     "plugins": [
         {
             "name": "coding-buddy",
             "source": "./",
             "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality. Requires bun runtime (https://bun.sh/install).",
-            "version": "0.8.0",
+            "version": "0.9.3",
             "author": {
                 "name": "ramarivera"
             },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "coding-buddy",
-    "version": "0.8.0",
+    "version": "0.9.3",
     "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality.",
     "author": {
         "name": "ramarivera"

--- a/server/index.ts
+++ b/server/index.ts
@@ -125,7 +125,7 @@ function getInstructions(): string {
 const server = new McpServer(
   {
     name: "coding-buddy",
-    version: "0.6.0",
+    version: "0.9.3",
   },
   {
     instructions: getInstructions(),


### PR DESCRIPTION
`package.json` has been the only version field that actually moves. Everything else drifted:

| Surface | Was | Now |
| --- | --- | --- |
| `package.json` | `0.9.3` | — (source of truth) |
| `.claude-plugin/plugin.json` :: `version` | `0.8.0` | `0.9.3` |
| `.claude-plugin/marketplace.json` :: `metadata.version` | `0.8.0` | `0.9.3` |
| `.claude-plugin/marketplace.json` :: `plugins[0].version` | `0.8.0` | `0.9.3` |
| `server/index.ts:128` — MCP server handshake | `0.6.0` | `0.9.3` |

The MCP one is the worst of them: that string is what the server advertises to every connecting client, and it was three minors behind.

**Numbers only, deliberately.** The recurrence is the real bug, and #110 from @grlee already fixes it properly — a `scripts/sync-version.ts` wired into the npm `version` lifecycle with a `--check` mode for CI, plus reading `pkg.version` in `server/index.ts` instead of a literal. This PR does not touch that design or conflict with its approach; it just stops the currently-published release from lying about itself. #110 is worth merging on top.

`bun test` → 471 pass, 0 fail. `bun run typecheck` clean.

🤖 *Created with the help of AI (Claude Opus 5).*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync plugin and MCP server version fields to 0.9.3
> Updates version strings in [marketplace.json](.claude-plugin/marketplace.json), [plugin.json](.claude-plugin/plugin.json), and the `McpServer` constructor in [server/index.ts](https://github.com/ramarivera/coding-buddy/pull/173/files#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68) from stale values (0.8.0 / 0.6.0) to 0.9.3.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 480cede.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the marketplace, plugin, and server versions to 0.9.3.
  * Ensured version information is consistent across the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->