### PR TITLE
feat(version): keep every version field in sync with package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check version fields are in sync
+        run: bun run sync-version --check
+
       - name: Typecheck
         run: bun run typecheck
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "gen:emoji-widths": "bun run scripts/gen-emoji-widths.ts",
+    "sync-version": "bun run scripts/sync-version.ts",
+    "version": "bun run sync-version && git add .claude-plugin",
     "ci:statusline": "bash scripts/ci/check-statusline.sh",
     "ci:vhs:render": "bash scripts/ci/render-vhs-goldens.sh",
     "ci:vhs:update": "bash scripts/ci/render-vhs-goldens.sh --update",

--- a/scripts/sync-version.test.ts
+++ b/scripts/sync-version.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { findDrift } from "./sync-version.ts";
+
+const ROOT = join(import.meta.dir, "..");
+const script = join(import.meta.dir, "sync-version.ts");
+const pkgVersion = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")).version;
+
+describe("sync-version", () => {
+  test("the repo's version fields are in sync with package.json", () => {
+    expect(findDrift()).toEqual([]);
+  });
+
+  test("--check exits 0 and reports the shared version when in sync", () => {
+    const result = spawnSync("bun", ["run", script, "--check"], { cwd: ROOT, encoding: "utf8" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`all version fields already at ${pkgVersion}`);
+  });
+
+  test("every manifest version field matches package.json", () => {
+    const plugin = JSON.parse(readFileSync(join(ROOT, ".claude-plugin/plugin.json"), "utf8"));
+    const market = JSON.parse(readFileSync(join(ROOT, ".claude-plugin/marketplace.json"), "utf8"));
+
+    expect(plugin.version).toBe(pkgVersion);
+    expect(market.metadata.version).toBe(pkgVersion);
+    for (const entry of market.plugins) expect(entry.version).toBe(pkgVersion);
+  });
+
+  test("the MCP handshake version is imported, never a literal", () => {
+    const source = readFileSync(join(ROOT, "server/index.ts"), "utf8");
+
+    expect(source).toContain("version: pkg.version,");
+    expect(source).not.toMatch(/version:\s*"\d+\.\d+\.\d+"/);
+  });
+});

--- a/scripts/sync-version.test.ts
+++ b/scripts/sync-version.test.ts
@@ -32,8 +32,12 @@ describe("sync-version", () => {
 
   test("the MCP handshake version is imported, never a literal", () => {
     const source = readFileSync(join(ROOT, "server/index.ts"), "utf8");
+    // Scoped to the new McpServer(...) options object — a semver literal
+    // elsewhere in the file is none of this test's business.
+    const options = source.match(/new McpServer\(\s*\{([\s\S]*?)\}/);
 
-    expect(source).toContain("version: pkg.version,");
-    expect(source).not.toMatch(/version:\s*"\d+\.\d+\.\d+"/);
+    expect(options).not.toBeNull();
+    expect(options![1]).toContain("version: pkg.version,");
+    expect(options![1]).not.toMatch(/version:\s*"\d+\.\d+\.\d+"/);
   });
 });

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -52,7 +52,12 @@ const TARGETS: Target[] = [
       {
         label: "metadata.version",
         get: () => doc.metadata?.version,
-        set: () => { if (doc.metadata) doc.metadata.version = version; },
+        // Creates metadata if absent. Guarding the write instead would let
+        // --check report drift that the fixer could never resolve.
+        set: () => {
+          doc.metadata ??= {};
+          doc.metadata.version = version;
+        },
       },
       ...(doc.plugins ?? []).map((plugin: any, i: number) => ({
         label: `plugins[${i}].version`,

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -1,0 +1,117 @@
+/**
+ * Sync every version field in the repo to package.json.
+ *
+ *   bun run sync-version           # rewrite drifted fields
+ *   bun run sync-version --check   # exit 1 on drift, change nothing (CI)
+ *
+ * Wired into the npm `version` lifecycle so `npm version <bump>` updates the
+ * manifests in the same commit as package.json, and into CI via --check so
+ * drift cannot land.
+ *
+ * Design and the original implementation come from #110 by @grlee. That PR
+ * conflicted with main and lives on a fork, so it is reimplemented here rather
+ * than rebased.
+ *
+ * server/index.ts is deliberately NOT a target — it imports pkg.version
+ * directly, which is strictly better than syncing a literal. Anything that can
+ * import package.json should do that instead of being added below.
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const ROOT = join(import.meta.dir, "..");
+const CHECK_ONLY = process.argv.includes("--check");
+
+const version: unknown = JSON.parse(
+  readFileSync(join(ROOT, "package.json"), "utf8"),
+).version;
+
+if (typeof version !== "string" || version === "") {
+  console.error("sync-version: package.json is missing a version field");
+  process.exit(2);
+}
+
+interface Target {
+  /** Repo-relative path. */
+  path: string;
+  /** Every version field in the document, for reporting and for rewriting. */
+  fields: (doc: any) => { label: string; get: () => string; set: () => void }[];
+}
+
+const TARGETS: Target[] = [
+  {
+    path: ".claude-plugin/plugin.json",
+    fields: (doc) => [
+      { label: "version", get: () => doc.version, set: () => { doc.version = version; } },
+    ],
+  },
+  {
+    path: ".claude-plugin/marketplace.json",
+    fields: (doc) => [
+      {
+        label: "metadata.version",
+        get: () => doc.metadata?.version,
+        set: () => { if (doc.metadata) doc.metadata.version = version; },
+      },
+      ...(doc.plugins ?? []).map((plugin: any, i: number) => ({
+        label: `plugins[${i}].version`,
+        get: () => plugin.version,
+        set: () => { plugin.version = version; },
+      })),
+    ],
+  },
+];
+
+export interface Drift {
+  path: string;
+  label: string;
+  current: string;
+}
+
+/** Returns every field that disagrees with package.json. Never writes. */
+export function findDrift(): Drift[] {
+  const drift: Drift[] = [];
+  for (const target of TARGETS) {
+    const doc = JSON.parse(readFileSync(join(ROOT, target.path), "utf8"));
+    for (const field of target.fields(doc)) {
+      const current = field.get();
+      if (current !== version) drift.push({ path: target.path, label: field.label, current });
+    }
+  }
+  return drift;
+}
+
+function main(): void {
+  const drift = findDrift();
+
+  for (const d of drift) {
+    console.log(
+      `${CHECK_ONLY ? "DRIFT" : "sync"}: ${d.path} :: ${d.label} ${d.current} -> ${version}`,
+    );
+  }
+
+  if (drift.length === 0) {
+    console.log(`sync-version: all version fields already at ${version}`);
+    return;
+  }
+
+  if (CHECK_ONLY) {
+    console.error(
+      "sync-version: version fields are out of sync with package.json. Run `bun run sync-version`.",
+    );
+    process.exit(1);
+  }
+
+  // Rewrite only the files that actually drifted, preserving 4-space style.
+  const drifted = new Set(drift.map((d) => d.path));
+  for (const target of TARGETS) {
+    if (!drifted.has(target.path)) continue;
+    const full = join(ROOT, target.path);
+    const doc = JSON.parse(readFileSync(full, "utf8"));
+    for (const field of target.fields(doc)) field.set();
+    writeFileSync(full, `${JSON.stringify(doc, null, 4)}\n`);
+  }
+}
+
+if (import.meta.main) main();

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,9 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { existsSync } from "fs";
 import { join, resolve, dirname } from "path";
+// The version advertised in the MCP handshake. Imported rather than written
+// as a literal so it cannot drift from the published package (it had, to 0.6.0).
+import pkg from "../package.json" with { type: "json" };
 
 import { generateBones,
 generatePersonality,
@@ -125,7 +128,7 @@ function getInstructions(): string {
 const server = new McpServer(
   {
     name: "coding-buddy",
-    version: "0.9.3",
+    version: pkg.version,
   },
   {
     instructions: getInstructions(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,17 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["bun-types"],
+    "types": [
+      "bun-types"
+    ],
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "moduleDetection": "force",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "resolveJsonModule": true
   },
   "include": [
     "server/**/*.ts",
@@ -19,6 +22,7 @@
     "core/**/*.ts",
     "adapters/**/*.ts",
     ".pi/**/*.ts",
-    ".omp/**/*.ts"
+    ".omp/**/*.ts",
+    "scripts/**/*.ts"
   ]
 }


### PR DESCRIPTION
`package.json` was the only version that moved. The plugin manifests fell three minors behind and the MCP handshake fell further still. #173 corrected those by hand — this stops it happening again.

- **`scripts/sync-version.ts`** rewrites drifted manifest fields, or under `--check` reports them and exits 1.
- **CI** runs `--check`, so drift cannot land.
- **The npm `version` lifecycle** runs the fixer and git-adds `.claude-plugin`, so a bump updates the manifests in the same commit as `package.json`.
- **`server/index.ts` imports `pkg.version`** instead of a literal — strictly better than syncing one. A test asserts no hardcoded semver returns to that call.

## Verified both directions

Not just "it passes":

```
$ # inject 0.1.0 into plugin.json
$ bun run sync-version --check
DRIFT: .claude-plugin/plugin.json :: version 0.1.0 -> 0.9.3
sync-version: version fields are out of sync with package.json.
exit 1

$ bun run sync-version
sync: .claude-plugin/plugin.json :: version 0.1.0 -> 0.9.3
exit 0
```

The fixer restores the file **byte-identically** — `git diff` is empty afterwards, so the 4-space manifest formatting round-trips.

`bun test` → **475 pass, 0 fail** (4 new). `bun run typecheck` clean.

## Credit

Design and the original implementation are from **#110 by @grlee**. That PR now conflicts with `main` and lives on a fork, so it could not be rebased — this reimplements the same approach. **#110 should be closed in favour of this one**, with thanks.

🤖 *Created with the help of AI (Claude Opus 5).*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep version fields in `.claude-plugin` manifests and MCP server in sync with `package.json`
> - Adds [scripts/sync-version.ts](https://github.com/ramarivera/coding-buddy/pull/174/files#diff-f44ff477aaa87d693b7fb08f8f4d1c6b71731d6b923a1b12442e8e79421bede8) to detect and fix version drift between `package.json` and the `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` manifests.
> - Wires the script into a `sync-version` npm script and a `version` lifecycle hook that stages manifest changes automatically on `npm version`.
> - Replaces the hardcoded version string in [server/index.ts](https://github.com/ramarivera/coding-buddy/pull/174/files#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68) with `pkg.version` imported from `package.json`.
> - Adds a CI step that runs `bun run sync-version --check` to fail the build on any drift.
> - Enables `resolveJsonModule` in [tsconfig.json](https://github.com/ramarivera/coding-buddy/pull/174/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0) and includes `scripts/**/*.ts` to support the new script and JSON import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d5d417.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->