### PR TITLE
chore: release 0.9.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     },
     "metadata": {
         "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi (requires bun: https://bun.sh/install)",
-        "version": "0.9.3"
+        "version": "0.9.4"
     },
     "plugins": [
         {
             "name": "coding-buddy",
             "source": "./",
             "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality. Requires bun runtime (https://bun.sh/install).",
-            "version": "0.9.3",
+            "version": "0.9.4",
             "author": {
                 "name": "ramarivera"
             },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "coding-buddy",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality.",
     "author": {
         "name": "ramarivera"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramarivera/coding-buddy",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi",
   "type": "module",
   "omp": {


### PR DESCRIPTION
**0.9.3 shipped a tarball that lied about itself.** It was published from the release commit, before the version-field fixes merged, so the published package still carries:

- `.claude-plugin/plugin.json` → `0.8.0`
- `.claude-plugin/marketplace.json` → `0.8.0`
- MCP handshake in `server/index.ts` → `0.6.0`

Verified by unpacking `npm pack @ramarivera/coding-buddy@0.9.3`. Nothing consuming the published package can see a correct version. This release ships them.

## Contents since 0.9.3

- **#173** — synced the plugin manifests and the MCP handshake version.
- **#174** — `scripts/sync-version.ts`, a CI drift check, and the npm `version` lifecycle hook.

#174 earned its keep immediately: this bump was `bun run sync-version` and all three manifest fields moved in one command. `server/index.ts` needed no edit at all since it now imports `pkg.version`.

`sync-version --check` → 0. `bun test` → 475 pass, 0 fail.

🤖 *Created with the help of AI (Claude Opus 5).*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.9.4
> Bumps the version from `0.9.3` to `0.9.4` in [package.json](https://github.com/ramarivera/coding-buddy/pull/176/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [plugin.json](https://github.com/ramarivera/coding-buddy/pull/176/files#diff-037fda53525563fb89230704794a06db1150204ca28ce80697a637121c3ed3f9), and [marketplace.json](https://github.com/ramarivera/coding-buddy/pull/176/files#diff-5352ee4067f17e7948e1425843f0a454e045bc8edf338f0bcf75c6804ddabd9a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56a753b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->